### PR TITLE
Fix CSV header sanitization and quote SQL identifiers

### DIFF
--- a/csv_importer.py
+++ b/csv_importer.py
@@ -11,8 +11,18 @@ class CSVImporter:
 
     @staticmethod
     def _map_header(header):
-        """Map a Cognism header to lower_snake_case."""
-        return header.strip().lower().replace(" ", "_").replace("/", "_")
+        """Map a Cognism header to lower_snake_case.
+
+        Hyphens and slashes are converted to underscores so the resulting
+        column names are valid in SQLite without additional quoting.
+        """
+        return (
+            header.strip()
+            .lower()
+            .replace(" ", "_")
+            .replace("/", "_")
+            .replace("-", "_")
+        )
 
     def import_contacts(self):
         """Read the CSV and insert rows into the contacts table."""

--- a/db_manager.py
+++ b/db_manager.py
@@ -143,7 +143,7 @@ class DBManager:
             values.append(value)
 
         placeholders = ", ".join(["?" for _ in columns])
-        cols_joined = ", ".join(columns)
+        cols_joined = ", ".join([f'"{c}"' for c in columns])
         sql = f"INSERT INTO contacts ({cols_joined}) VALUES ({placeholders})"
         conn.execute(sql, values)
         conn.commit()
@@ -163,7 +163,7 @@ class DBManager:
         for column, value in data.items():
             if column not in valid_columns:
                 raise ValueError(f"Invalid column name: {column}")
-            updates.append(f"{column} = ?")
+            updates.append(f'"{column}" = ?')
             params.append(value)
         if not updates:
             return
@@ -209,7 +209,7 @@ class DBManager:
             for column, value in filters.items():
                 if column not in valid_columns:
                     raise ValueError(f"Invalid column name: {column}")
-                clauses.append(f"{column} = ?")
+                clauses.append(f'"{column}" = ?')
                 params.append(value)
             if clauses:
                 sql += " WHERE " + " AND ".join(clauses)


### PR DESCRIPTION
## Summary
- sanitize CSV headers to replace hyphens with underscores
- quote column names when inserting and updating
- quote filter columns

## Testing
- `python3 -m py_compile csv_importer.py db_manager.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6857c200c3508332ade1205ca6408145