### PR TITLE
Fix CSV header mapping

### DIFF
--- a/csv_importer.py
+++ b/csv_importer.py
@@ -1,4 +1,5 @@
 import csv
+import re
 from datetime import datetime
 from db_manager import DBManager
 
@@ -16,13 +17,10 @@ class CSVImporter:
         Hyphens and slashes are converted to underscores so the resulting
         column names are valid in SQLite without additional quoting.
         """
-        return (
-            header.strip()
-            .lower()
-            .replace(" ", "_")
-            .replace("/", "_")
-            .replace("-", "_")
-        )
+        cleaned = header.strip().lower()
+        # replace any combination of spaces, slashes or hyphens with one underscore
+        cleaned = re.sub(r"[\s/-]+", "_", cleaned)
+        return cleaned
 
     def import_contacts(self):
         """Read the CSV and insert rows into the contacts table."""


### PR DESCRIPTION
## Summary
- handle hyphen + space sequences when mapping Cognism headers
- import regex module to clean up mapping logic

## Testing
- `python3 -m py_compile csv_importer.py db_manager.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6857c318b8cc833293895c8b412fdde2