### PR TITLE
Improve main window layout with toolbar

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,10 +4,14 @@ from PyQt5.QtWidgets import (
     QFileDialog,
     QLineEdit,
     QMainWindow,
-    QPushButton,
+    QToolBar,
+    QAction,
+    QStyle,
+    QHBoxLayout,
     QVBoxLayout,
     QWidget,
 )
+from PyQt5.QtCore import Qt, QSize
 
 from db_manager import DBManager
 from csv_importer import CSVImporter
@@ -26,18 +30,50 @@ class MainWindow(QMainWindow):
     def _setup_ui(self):
         central = QWidget()
         self.setCentralWidget(central)
-        layout = QVBoxLayout(central)
+        main_layout = QVBoxLayout(central)
 
-        self.import_button = QPushButton("Import CSV")
-        self.import_button.clicked.connect(self._import_csv)
-        layout.addWidget(self.import_button)
-
+        # Search bar and tag filter row
+        search_row = QHBoxLayout()
         self.search_bar = QLineEdit()
         self.search_bar.setPlaceholderText("Search contacts...")
-        layout.addWidget(self.search_bar)
+        search_row.addWidget(self.search_bar, 1)
 
         self.table_widget = ContactsTableWidget(self.db)
-        layout.addWidget(self.table_widget)
+        search_row.addWidget(self.table_widget.tag_filter)
+        main_layout.addLayout(search_row)
+
+        # Horizontal toolbar with compact actions
+        toolbar = QToolBar()
+        toolbar.setIconSize(QSize(16, 16))
+
+        import_action = QAction(self.style().standardIcon(QStyle.SP_DirOpenIcon), "Import", self)
+        import_action.setToolTip("Import contacts from CSV")
+        import_action.triggered.connect(self._import_csv)
+        toolbar.addAction(import_action)
+
+        add_tag_action = QAction(self.style().standardIcon(QStyle.SP_FileDialogNewFolder), "Add Tag", self)
+        add_tag_action.setToolTip("Add tag to all visible contacts")
+        add_tag_action.triggered.connect(self.table_widget._batch_add_tag)
+        toolbar.addAction(add_tag_action)
+
+        remove_tag_action = QAction(self.style().standardIcon(QStyle.SP_TrashIcon), "Remove Tag", self)
+        remove_tag_action.setToolTip("Remove tag from all visible contacts")
+        remove_tag_action.triggered.connect(self.table_widget._batch_remove_tag)
+        toolbar.addAction(remove_tag_action)
+
+        status_action = QAction(self.style().standardIcon(QStyle.SP_DialogApplyButton), "Set Status", self)
+        status_action.setToolTip("Set status for all visible contacts")
+        status_action.triggered.connect(self.table_widget._batch_set_status)
+        toolbar.addAction(status_action)
+
+        columns_action = QAction(self.style().standardIcon(QStyle.SP_FileDialogContentsView), "Columns", self)
+        columns_action.setToolTip("Customize visible columns")
+        columns_action.triggered.connect(self.table_widget._customize_columns)
+        toolbar.addAction(columns_action)
+
+        main_layout.addWidget(toolbar)
+
+        main_layout.addWidget(self.table_widget)
 
         self.search_bar.textChanged.connect(self.table_widget.set_search_text)
 

--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -1,7 +1,6 @@
 from PyQt5.QtWidgets import (
     QWidget,
     QVBoxLayout,
-    QPushButton,
     QTableWidget,
     QTableWidgetItem,
     QComboBox,
@@ -81,25 +80,10 @@ class ContactsTableWidget(QWidget):
     def _setup_ui(self):
         layout = QVBoxLayout(self)
 
-        self.add_tag_button = QPushButton("Add Tag to All Visible")
-        self.add_tag_button.clicked.connect(self._batch_add_tag)
-        layout.addWidget(self.add_tag_button)
-
-        self.remove_tag_button = QPushButton("Remove Tag from All Visible")
-        self.remove_tag_button.clicked.connect(self._batch_remove_tag)
-        layout.addWidget(self.remove_tag_button)
-
-        self.status_all_button = QPushButton("Set Status for All Visible")
-        self.status_all_button.clicked.connect(self._batch_set_status)
-        layout.addWidget(self.status_all_button)
-
-        self.column_settings_button = QPushButton("Customize Columns")
-        self.column_settings_button.clicked.connect(self._customize_columns)
-        layout.addWidget(self.column_settings_button)
-
+        # Tag filter dropdown is created here but not added to the internal
+        # layout so the main window can position it next to the search bar.
         self.tag_filter = CheckableComboBox()
         self.tag_filter.currentIndexChanged.connect(self._apply_filters)
-        layout.addWidget(self.tag_filter)
 
         self.table = QTableWidget()
         self.table.setColumnCount(len(self.HEADERS))


### PR DESCRIPTION
## Summary
- replace old vertical buttons with a horizontal toolbar
- move tag filter next to the search bar
- remove buttons from `ContactsTableWidget`
- keep batch actions accessible through the toolbar

## Testing
- `python -m py_compile main.py db_manager.py csv_importer.py ui/contacts_table.py`

------
https://chatgpt.com/codex/tasks/task_e_6857cf2b7d1883328aeb6babf6afa1bb