### PR TITLE
Add settings panel and persistent configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A small demo application for importing Cognism CSV files into a SQLite database 
 * **csv_importer.py** – parses a CSV file and stores the contents in the database.
 * **db_manager.py** – manages the SQLite connection and schema.
 * **ui/contacts_table.py** – contains the contact table widget with inline editing and batch actions.
-* **main.py** – launches the application window and wires up the components.
+* **ui/settings_panel.py** – user interface for editing API keys, prompt templates and time zone options.
+* **config/settings.py** – loads and saves persistent configuration in the user's home directory.
+* **main.py** – launches the application window and wires up the components. The toolbar now includes a **Settings** button to open the configuration dialog.
 
 Import contacts by creating a `CSVImporter` instance pointing to your CSV file and calling `import_contacts()` or using the **Import CSV** button in the GUI.

--- a/config/settings.py
+++ b/config/settings.py
@@ -1,0 +1,83 @@
+# Configuration management for AI Contact Manager
+
+import json
+import os
+from pathlib import Path
+
+CONFIG_FILE = Path.home() / ".ai_contact_manager_config.json"
+
+DEFAULT_SETTINGS = {
+    "openai_api_key": "",
+    "llm_model": "gpt-3.5-turbo",
+    "prompts": {
+        "target_company_validation": "",
+        "icp_validation": "",
+        "clients_of_contact": "",
+        "area_of_business": "",
+        "most_relevant_summit": "",
+        "client_icp": "",
+        "time_zone_lookup": "",
+    },
+    "timezone": {
+        "utc_offset": 0,
+        "morning_call": "09:00",
+        "afternoon_call": "15:00",
+    },
+}
+
+_settings = None
+
+
+def load_settings():
+    """Load settings from the config file or return defaults."""
+    global _settings
+    if CONFIG_FILE.exists():
+        try:
+            with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+                _settings = json.load(f)
+        except json.JSONDecodeError:
+            _settings = DEFAULT_SETTINGS.copy()
+    else:
+        _settings = DEFAULT_SETTINGS.copy()
+    # Ensure all keys exist
+    _merge_defaults(_settings, DEFAULT_SETTINGS)
+    return _settings
+
+
+def save_settings():
+    """Persist current settings to disk."""
+    if _settings is None:
+        return
+    CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+        json.dump(_settings, f, indent=2)
+
+
+def get_settings():
+    """Return the settings dictionary, loading it if necessary."""
+    if _settings is None:
+        return load_settings()
+    return _settings
+
+
+def update_setting(path, value):
+    """Update a nested setting using dot-separated path."""
+    keys = path.split(".")
+    settings = get_settings()
+    obj = settings
+    for k in keys[:-1]:
+        obj = obj.setdefault(k, {})
+    obj[keys[-1]] = value
+    save_settings()
+
+
+def _merge_defaults(target, defaults):
+    for key, val in defaults.items():
+        if isinstance(val, dict):
+            target.setdefault(key, {})
+            _merge_defaults(target[key], val)
+        else:
+            target.setdefault(key, val)
+
+# Load settings on import
+load_settings()

--- a/main.py
+++ b/main.py
@@ -16,6 +16,8 @@ from PyQt5.QtCore import Qt, QSize
 from db_manager import DBManager
 from csv_importer import CSVImporter
 from ui.contacts_table import ContactsTableWidget
+from ui.settings_panel import SettingsDialog
+from config.settings import get_settings
 
 
 class MainWindow(QMainWindow):
@@ -71,11 +73,20 @@ class MainWindow(QMainWindow):
         columns_action.triggered.connect(self.table_widget._customize_columns)
         toolbar.addAction(columns_action)
 
+        settings_action = QAction(self.style().standardIcon(QStyle.SP_FileDialogDetailedView), "Settings", self)
+        settings_action.setToolTip("Application and AI settings")
+        settings_action.triggered.connect(self._open_settings)
+        toolbar.addAction(settings_action)
+
         main_layout.addWidget(toolbar)
 
         main_layout.addWidget(self.table_widget)
 
         self.search_bar.textChanged.connect(self.table_widget.set_search_text)
+
+    def _open_settings(self):
+        dialog = SettingsDialog(self)
+        dialog.exec()
 
     def _import_csv(self):
         file_path, _ = QFileDialog.getOpenFileName(

--- a/ui/settings_panel.py
+++ b/ui/settings_panel.py
@@ -1,0 +1,120 @@
+from PyQt5.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPlainTextEdit,
+    QSpinBox,
+    QTimeEdit,
+    QVBoxLayout,
+    QWidget,
+    QComboBox,
+)
+from PyQt5.QtCore import Qt, QTime
+from typing import Optional
+
+from config.settings import get_settings, update_setting
+
+
+class SettingsDialog(QDialog):
+    """Dialog for editing application and AI settings."""
+
+    def __init__(self, parent: Optional[QWidget] = None):
+        super().__init__(parent)
+        self.setWindowTitle("Settings")
+        self._settings = get_settings()
+        self._build_ui()
+
+    def _build_ui(self):
+        layout = QVBoxLayout(self)
+
+        form = QFormLayout()
+        # API Key
+        self.api_key_edit = QLineEdit(self._settings.get("openai_api_key", ""))
+        self.api_key_edit.setEchoMode(QLineEdit.Password)
+        self.api_key_edit.setPlaceholderText("sk-...")
+        self.api_key_edit.setToolTip("Your OpenAI API key")
+        self.api_key_edit.editingFinished.connect(
+            lambda: update_setting("openai_api_key", self.api_key_edit.text())
+        )
+        form.addRow("OpenAI API Key", self.api_key_edit)
+
+        # Model selection
+        self.model_combo = QComboBox()
+        self.model_combo.addItems(["gpt-3.5-turbo", "gpt-4"])
+        self.model_combo.setCurrentText(self._settings.get("llm_model", "gpt-3.5-turbo"))
+        self.model_combo.currentTextChanged.connect(
+            lambda text: update_setting("llm_model", text)
+        )
+        form.addRow("LLM Model", self.model_combo)
+
+        layout.addLayout(form)
+
+        # Prompts section
+        prompts_box = QGroupBox("Prompt Templates")
+        prompts_layout = QFormLayout(prompts_box)
+        psettings = self._settings.get("prompts", {})
+        self.prompt_edits = {}
+        prompts = [
+            ("target_company_validation", "Target Company Validation"),
+            ("icp_validation", "ICP Validation"),
+            ("clients_of_contact", "Clients of Contact"),
+            ("area_of_business", "Area of Business"),
+            ("most_relevant_summit", "Most Relevant Summit"),
+            ("client_icp", "ICP of the Client"),
+            ("time_zone_lookup", "Time Zone Lookup"),
+        ]
+        for key, label in prompts:
+            edit = QPlainTextEdit(psettings.get(key, ""))
+            edit.setToolTip(f"Prompt template for {label}")
+            edit.textChanged.connect(
+                lambda k=key, e=edit: update_setting(f"prompts.{k}", e.toPlainText())
+            )
+            prompts_layout.addRow(label, edit)
+            self.prompt_edits[key] = edit
+        layout.addWidget(prompts_box)
+
+        # Time zone settings
+        tz_box = QGroupBox("Time Zone")
+        tz_layout = QFormLayout(tz_box)
+        tz_settings = self._settings.get("timezone", {})
+
+        self.utc_offset_spin = QSpinBox()
+        self.utc_offset_spin.setRange(-12, 14)
+        self.utc_offset_spin.setValue(int(tz_settings.get("utc_offset", 0)))
+        self.utc_offset_spin.setToolTip("Default UTC offset")
+        self.utc_offset_spin.valueChanged.connect(
+            lambda val: update_setting("timezone.utc_offset", val)
+        )
+        tz_layout.addRow("UTC Offset", self.utc_offset_spin)
+
+        self.morning_time = QTimeEdit()
+        self.morning_time.setDisplayFormat("HH:mm")
+        self.morning_time.setTime(
+            QTime.fromString(tz_settings.get("morning_call", "09:00"), "HH:mm")
+        )
+        self.morning_time.timeChanged.connect(
+            lambda t: update_setting("timezone.morning_call", t.toString("HH:mm"))
+        )
+        tz_layout.addRow("Morning Call", self.morning_time)
+
+        self.afternoon_time = QTimeEdit()
+        self.afternoon_time.setDisplayFormat("HH:mm")
+        self.afternoon_time.setTime(
+            QTime.fromString(tz_settings.get("afternoon_call", "15:00"), "HH:mm")
+        )
+        self.afternoon_time.timeChanged.connect(
+            lambda t: update_setting("timezone.afternoon_call", t.toString("HH:mm"))
+        )
+        tz_layout.addRow("Afternoon Call", self.afternoon_time)
+
+        layout.addWidget(tz_box)
+
+        # Buttons
+        buttons = QDialogButtonBox(QDialogButtonBox.Close)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+


### PR DESCRIPTION
## Summary
- add persistent settings management under `config/`
- implement UI dialog for editing LLM settings, prompt templates, and timezone defaults
- include Settings button in the toolbar
- document new modules and functionality

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857d2e948948332826e96d172fa3449