### PR TITLE
Integrate updated OpenAI library

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,30 @@ A small demo application for importing Cognism CSV files into a SQLite database 
 * **main.py** – launches the application window and wires up the components. The toolbar now includes a **Settings** button to open the configuration dialog.
 
 Import contacts by creating a `CSVImporter` instance pointing to your CSV file and calling `import_contacts()` or using the **Import CSV** button in the GUI.
+
+## Using OpenAI
+
+Configure your OpenAI API key and preferred model in the **Settings** dialog. The application uses the official `openai` Python library with the following pattern:
+
+```python
+from openai import OpenAI
+
+client = OpenAI()
+
+completion = client.chat.completions.create(
+    model="gpt-4.1",
+    messages=[{"role": "user", "content": "Write a one-sentence bedtime story about a unicorn."}]
+)
+
+print(completion.choices[0].message.content)
+```
+
+Available models you can select are:
+
+- `gpt-4.1`
+- `gpt-4.1-mini`
+- `gpt-4.1-nano`
+- `gpt-4o-mini`
+- `o3-mini`
+
+Use only the base model name (e.g. `"gpt-4.1"`) without any date suffixes.

--- a/ai/llm_manager.py
+++ b/ai/llm_manager.py
@@ -1,4 +1,4 @@
-import openai
+from openai import OpenAI
 from config.settings import get_settings
 
 
@@ -26,10 +26,10 @@ def run_prompt(prompt_name: str, variables: dict | None = None, clean: bool = Tr
         raise RuntimeError(f"Prompt template '{prompt_name}' not configured")
     variables = variables or {}
     prompt = template.format(**variables)
-    openai.api_key = api_key
-    response = openai.ChatCompletion.create(
+    client = OpenAI(api_key=api_key)
+    response = client.chat.completions.create(
         model=model,
         messages=[{"role": "user", "content": prompt}],
     )
-    text = response.choices[0].message["content"]
+    text = response.choices[0].message.content
     return text.strip() if clean else text

--- a/config/settings.py
+++ b/config/settings.py
@@ -8,7 +8,7 @@ CONFIG_FILE = Path.home() / ".ai_contact_manager_config.json"
 
 DEFAULT_SETTINGS = {
     "openai_api_key": "",
-    "llm_model": "gpt-3.5-turbo",
+    "llm_model": "gpt-4.1",
     "prompts": {
         "target_company_validation": "",
         "icp_validation": "",

--- a/ui/settings_panel.py
+++ b/ui/settings_panel.py
@@ -44,8 +44,14 @@ class SettingsDialog(QDialog):
 
         # Model selection
         self.model_combo = QComboBox()
-        self.model_combo.addItems(["gpt-3.5-turbo", "gpt-4"])
-        self.model_combo.setCurrentText(self._settings.get("llm_model", "gpt-3.5-turbo"))
+        self.model_combo.addItems([
+            "gpt-4.1",
+            "gpt-4.1-mini",
+            "gpt-4.1-nano",
+            "gpt-4o-mini",
+            "o3-mini",
+        ])
+        self.model_combo.setCurrentText(self._settings.get("llm_model", "gpt-4.1"))
         self.model_combo.currentTextChanged.connect(
             lambda text: update_setting("llm_model", text)
         )


### PR DESCRIPTION
## Summary
- update OpenAI client usage
- default to `gpt-4.1`
- offer new model list in settings
- document how to call OpenAI and list available models

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857de48e1188332a6952faf016f72c2