### PR TITLE
Update timezone enrichment logic

### DIFF
--- a/ai/enrichment.py
+++ b/ai/enrichment.py
@@ -1,6 +1,9 @@
 from typing import Callable, Dict, List
+from datetime import datetime, timedelta
+
 from db_manager import DBManager
-from .llm_manager import run_prompt, is_configured
+from config.settings import get_settings
+from .llm_manager import run_prompt, is_configured, lookup_utc_offset
 
 
 AI_FIELDS = [
@@ -10,6 +13,27 @@ AI_FIELDS = [
     "client_icp",
     "time_zone_utc",
 ]
+
+
+def _shift_time(time_str: str, hours: int) -> str:
+    dt = datetime.strptime(time_str, "%H:%M")
+    dt += timedelta(hours=hours)
+    return dt.strftime("%H:%M")
+
+
+def _calculate_call_times(offset: str) -> tuple[str, str]:
+    tz = get_settings().get("timezone", {})
+    user_offset = int(tz.get("utc_offset", 0))
+    morning = tz.get("morning_call", "09:00")
+    afternoon = tz.get("afternoon_call", "15:00")
+
+    try:
+        contact_offset = int(str(offset))
+    except (TypeError, ValueError):
+        return "NA", "NA"
+
+    diff = contact_offset - user_offset
+    return _shift_time(morning, diff), _shift_time(afternoon, diff)
 
 
 def estimate_steps(db: DBManager) -> int:
@@ -103,9 +127,30 @@ def enrich_database(
                         progress_callback(step, total)
                 if not c.get("time_zone_utc"):
                     try:
-                        result = run_prompt("time_zone_lookup", c)
-                        db.update_contact(c["profile_id"], {"time_zone_utc": result})
+                        result = lookup_utc_offset(
+                            c.get("country", ""),
+                            c.get("state", ""),
+                            c.get("city", ""),
+                        )
+                        morning, afternoon = _calculate_call_times(result)
+                        db.update_contact(
+                            c["profile_id"],
+                            {
+                                "time_zone_utc": result,
+                                "morning_call_time": morning,
+                                "afternoon_call_time": afternoon,
+                            },
+                        )
                     except Exception as exc:  # noqa: BLE001
                         status_callback(str(exc))
                     step += 1
                     progress_callback(step, total)
+                elif not c.get("morning_call_time") or not c.get("afternoon_call_time"):
+                    morning, afternoon = _calculate_call_times(c.get("time_zone_utc"))
+                    db.update_contact(
+                        c["profile_id"],
+                        {
+                            "morning_call_time": morning,
+                            "afternoon_call_time": afternoon,
+                        },
+                    )

--- a/ai/llm_manager.py
+++ b/ai/llm_manager.py
@@ -67,3 +67,24 @@ def run_prompt(prompt_name: str, variables: dict | None = None, clean: bool = Tr
     )
     text = response.choices[0].message.content
     return text.strip() if clean else text
+
+
+def lookup_utc_offset(country: str, state: str, city: str) -> str:
+    """Return UTC offset for the given location using a dedicated prompt."""
+    api_key, model, _ = _get_openai_config()
+    if not api_key or not model:
+        raise RuntimeError("OpenAI API key or model not configured")
+
+    prompt = (
+        "Given the following information, provide ONLY the UTC offset as an "
+        "integer (e.g. -4, 0, +2, etc.). If the location is not available or "
+        "incomplete, respond with NA. Do not add any explanation or extra text.\n"
+        f"Country: {country}\nState: {state}\nCity: {city}\nUTC offset:"
+    )
+
+    client = OpenAI(api_key=api_key)
+    response = client.chat.completions.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+    )
+    return response.choices[0].message.content.strip()

--- a/config/settings.py
+++ b/config/settings.py
@@ -16,7 +16,6 @@ DEFAULT_SETTINGS = {
         "area_of_business": "",
         "most_relevant_summit": "",
         "client_icp": "",
-        "time_zone_lookup": "",
     },
     "timezone": {
         "utc_offset": 0,

--- a/ui/settings_panel.py
+++ b/ui/settings_panel.py
@@ -71,7 +71,6 @@ class SettingsDialog(QDialog):
             ("area_of_business", "Area of Business"),
             ("most_relevant_summit", "Most Relevant Summit"),
             ("client_icp", "ICP of the Client"),
-            ("time_zone_lookup", "Time Zone Lookup"),
         ]
         for key, label in prompts:
             edit = QPlainTextEdit(psettings.get(key, ""))


### PR DESCRIPTION
## Summary
- remove editable time zone prompt from settings
- add dedicated UTC offset prompt logic
- compute morning/afternoon call times from contact UTC offset

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857ed84a7408332b0a39875e16f63a4