### PR TITLE
Improve disposition logic and table fields

### DIFF
--- a/db_manager.py
+++ b/db_manager.py
@@ -137,11 +137,16 @@ class DBManager:
         self.create_contacts_table()
         conn = self.connect()
 
-        columns = []
-        values = []
-        for key, value in data.items():
-            columns.append(key)
-            values.append(value)
+        # Apply defaults and derive status from disposition
+        from utils import disposition_to_status
+
+        data = dict(data)
+        disposition = data.get("contact_disposition") or "not_defined"
+        data["contact_disposition"] = disposition
+        data.setdefault("status", disposition_to_status(disposition))
+
+        columns = list(data.keys())
+        values = list(data.values())
 
         placeholders = ", ".join(["?" for _ in columns])
         cols_joined = ", ".join([f'"{c}"' for c in columns])

--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -62,6 +62,11 @@ class ContactsTableWidget(QWidget):
         "email",
         "company_name",
         "website",
+        "country",
+        "state",
+        "city",
+        "morning_call_time",
+        "afternoon_call_time",
         "target_company",
         "contact_icp_status",
         "clients_of_contact",
@@ -73,7 +78,6 @@ class ContactsTableWidget(QWidget):
         "personal_linkedin_url",
         "contact_disposition",
         "tags",
-        "state",
         "status",
     ]
 
@@ -168,6 +172,7 @@ class ContactsTableWidget(QWidget):
                 if header == "contact_disposition":
                     combo = QComboBox()
                     dispositions = [
+                        "not_defined",
                         "connected_positive",
                         "connected_meeting_booked",
                         "connected_neutral",
@@ -204,14 +209,10 @@ class ContactsTableWidget(QWidget):
                         lambda value, cid=contact.get("profile_id"): self._on_status_changed(cid, value)
                     )
                     self.table.setCellWidget(row, col, combo)
-                elif header in ["email", "personal_linkedin_url"]:
+                elif header in ["website", "personal_linkedin_url"]:
                     value = str(contact.get(header, ""))
                     if value:
-                        if header == "email":
-                            href = f"mailto:{value}"
-                        else:
-                            href = value
-                        label = QLabel(f"<a href='{href}'>{value}</a>")
+                        label = QLabel(f"<a href='{value}'>{value}</a>")
                         label.setOpenExternalLinks(True)
                         label.setProperty("raw", value)
                         label.linkActivated.connect(
@@ -272,7 +273,13 @@ class ContactsTableWidget(QWidget):
     def _on_disposition_changed(self, contact_id, disposition):
         if not contact_id:
             return
-        self.db.update_contact(contact_id, {"contact_disposition": disposition})
+        from utils import disposition_to_status
+
+        status = disposition_to_status(disposition)
+        self.db.update_contact(
+            contact_id,
+            {"contact_disposition": disposition, "status": status},
+        )
         self.contacts = self.db.fetch_contacts()
         self._apply_filters()
         self._status_callback("Disposition updated")

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,20 @@
+INACTIVE_DISPOSITIONS = {
+    "not_defined",
+    "wrong_number",
+    "not_in_service",
+    "do_not_call",
+    "referred_to_another_contact",
+    "unreachable",
+    "wrong_company",
+    "connected_negative",
+    "connected_meeting_booked",
+    "connected_positive",
+}
+
+
+def disposition_to_status(disposition: str) -> str:
+    """Return the status string for a given contact disposition."""
+    if not disposition:
+        disposition = "not_defined"
+    return "inactive" if disposition in INACTIVE_DISPOSITIONS else "active"
+


### PR DESCRIPTION
## Summary
- derive status from disposition and set defaults on insert
- add country, state, city and call time columns
- copy email on double-click and make website clickable
- synchronize status when disposition changes
- provide helper for disposition->status mapping

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857f0a57ee8833290e4f47bac88f3ed