### PR TITLE
Fix initialization order bug in contacts table

### DIFF
--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -421,7 +421,8 @@ class ContactsTableWidget(QWidget):
             self.sort_order = (
                 Qt.DescendingOrder if sort.get("order") == "desc" else Qt.AscendingOrder
             )
-        self._update_header_icons()
+        if hasattr(self, "table"):
+            self._update_header_icons()
 
     def _apply_layout(self):
         header = self.table.horizontalHeader()


### PR DESCRIPTION
## Summary
- avoid using ContactsTableWidget.table before it's created

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857f6ff4db08332932042afe54e714c