### PR TITLE
Improve filter dropdown behavior

### DIFF
--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -11,15 +11,14 @@ from PyQt5.QtWidgets import (
     QFormLayout,
     QLabel,
     QApplication,
-    QHeaderView,
-    QStyle,
 )
-from PyQt5.QtGui import QIcon, QColor, QBrush
+from PyQt5.QtGui import QBrush
 from PyQt5.QtCore import Qt, QPoint
 
 from db_manager import DBManager
 from config.settings import get_settings, save_settings
 from ui.filter_popup import FilterPopup
+from ui.filter_header import FilterHeader
 
 
 class ContactsTableWidget(QWidget):
@@ -72,18 +71,20 @@ class ContactsTableWidget(QWidget):
         self.table = QTableWidget()
         self.table.setColumnCount(len(self.HEADERS))
         self.table.setHorizontalHeaderLabels(self.HEADERS)
-        self.table.horizontalHeader().setSectionsMovable(True)
+        header = FilterHeader()
+        self.table.setHorizontalHeader(header)
+        header.setSectionsMovable(True)
         self.table.setEditTriggers(
             QTableWidget.DoubleClicked | QTableWidget.EditKeyPressed
         )
         self.table.itemChanged.connect(self._on_item_changed)
         self.table.cellDoubleClicked.connect(self._handle_cell_double_clicked)
         self.table.setSortingEnabled(False)
-        header = self.table.horizontalHeader()
         header.setSectionsClickable(True)
-        header.sectionClicked.connect(self._open_filter_popup)
+        header.filter_requested.connect(self._open_filter_popup)
         header.setContextMenuPolicy(Qt.CustomContextMenu)
         header.customContextMenuRequested.connect(self._show_filter_context)
+        self._filter_header = header
         layout.addWidget(self.table)
 
         self._apply_layout()
@@ -349,6 +350,8 @@ class ContactsTableWidget(QWidget):
         section_left = header.sectionViewportPosition(logical)
         global_pos = header.mapToGlobal(QPoint(section_left, header.height()))
         popup.move(global_pos)
+        popup.closed.connect(lambda: self._filter_header.set_active_section(None))
+        self._filter_header.set_active_section(logical)
         popup.show()
 
     def _show_filter_context(self, pos):
@@ -363,7 +366,7 @@ class ContactsTableWidget(QWidget):
             self.filters.pop(field, None)
         else:
             self.filters[field] = selected
-        self._update_header_icons()
+        self._update_header_styles()
         self._apply_filters()
         self.save_layout()
 
@@ -374,19 +377,19 @@ class ContactsTableWidget(QWidget):
         self._apply_filters()
         self.save_layout()
 
-    def _update_header_icons(self):
-        normal_icon = self.style().standardIcon(QStyle.SP_ArrowDown)
-        active_icon = self.style().standardIcon(QStyle.SP_DialogApplyButton)
+    def _update_header_styles(self):
         for idx, name in enumerate(self.HEADERS):
             item = self.table.horizontalHeaderItem(idx)
             if item is None:
                 continue
+            font = item.font()
             if name in self.filters:
-                item.setIcon(active_icon)
                 item.setBackground(self.palette().highlight())
+                font.setBold(True)
             else:
-                item.setIcon(normal_icon)
                 item.setBackground(QBrush())
+                font.setBold(False)
+            item.setFont(font)
 
     def _handle_cell_double_clicked(self, row, column):
         header_view = self.table.horizontalHeader()
@@ -415,7 +418,7 @@ class ContactsTableWidget(QWidget):
                 Qt.DescendingOrder if sort.get("order") == "desc" else Qt.AscendingOrder
             )
         if hasattr(self, "table"):
-            self._update_header_icons()
+            self._update_header_styles()
 
     def _apply_layout(self):
         header = self.table.horizontalHeader()
@@ -427,7 +430,7 @@ class ContactsTableWidget(QWidget):
             self.table.setColumnHidden(idx, not self.column_visibility.get(name, True))
             if name in getattr(self, "column_widths", {}):
                 header.resizeSection(idx, self.column_widths[name])
-        self._update_header_icons()
+        self._update_header_styles()
 
     def save_layout(self):
         header = self.table.horizontalHeader()

--- a/ui/filter_header.py
+++ b/ui/filter_header.py
@@ -1,0 +1,60 @@
+from PyQt5.QtWidgets import QHeaderView, QToolButton
+from PyQt5.QtCore import Qt, pyqtSignal
+
+
+class FilterHeader(QHeaderView):
+    """Horizontal header showing filter arrows on hover or when active."""
+
+    filter_requested = pyqtSignal(int)
+
+    def __init__(self, parent=None):
+        super().__init__(Qt.Horizontal, parent)
+        self.setMouseTracking(True)
+        self._hover_section = None
+        self._active_section = None
+        self._button = QToolButton(self)
+        self._button.setText("\u25BC")  # down arrow
+        self._button.setFixedSize(16, 16)
+        self._button.hide()
+        self._button.clicked.connect(self._button_clicked)
+        self.sectionResized.connect(lambda *_: self._update_button())
+        self.sectionMoved.connect(lambda *_: self._update_button())
+
+    def _button_clicked(self):
+        if self._hover_section is not None:
+            self._active_section = self._hover_section
+            self.filter_requested.emit(self._hover_section)
+
+    def mouseMoveEvent(self, event):
+        super().mouseMoveEvent(event)
+        index = self.logicalIndexAt(event.pos())
+        if index != self._hover_section:
+            self._hover_section = index
+            self._update_button()
+
+    def leaveEvent(self, event):
+        super().leaveEvent(event)
+        self._hover_section = None
+        if self._active_section is None:
+            self._button.hide()
+
+    def _update_button(self):
+        section = self._active_section if self._active_section is not None else self._hover_section
+        if section is None:
+            self._button.hide()
+            return
+        rect = self.sectionRect(section)
+        x = rect.right() - self._button.width() - 2
+        y = rect.center().y() - self._button.height() // 2
+        self._button.move(x, y)
+        self._button.show()
+
+    def set_active_section(self, index):
+        self._active_section = index
+        self._update_button()
+        if index is None and self._hover_section is None:
+            self._button.hide()
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        self._update_button()

--- a/ui/filter_popup.py
+++ b/ui/filter_popup.py
@@ -15,6 +15,7 @@ class FilterPopup(QWidget):
 
     selection_changed = pyqtSignal()
     sort_requested = pyqtSignal(Qt.SortOrder)
+    closed = pyqtSignal()
 
     def __init__(self, values, parent=None):
         super().__init__(parent, Qt.Popup)
@@ -87,6 +88,14 @@ class FilterPopup(QWidget):
         for i in range(self.list_widget.count()):
             self.list_widget.item(i).setCheckState(Qt.Unchecked)
         self.selection_changed.emit()
+
+    def closeEvent(self, event):
+        self.closed.emit()
+        super().closeEvent(event)
+
+    def hideEvent(self, event):
+        self.closed.emit()
+        super().hideEvent(event)
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Escape:


### PR DESCRIPTION
## Summary
- add `FilterHeader` to show dropdown arrows on hover
- highlight active filters without always showing arrow icons
- keep dropdown arrow visible while filter popup is open
- emit close events from `FilterPopup`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6857fd3bd3c083329f0d42bf52f2fc94