### PR TITLE
Add color highlighting for dispositions and status

### DIFF
--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -20,6 +20,12 @@ from config.settings import get_settings, save_settings
 from ui.filter_popup import FilterPopup
 from ui.filter_header import FilterHeader
 from ui.tag_tools import TagSelectionDialog, ModeIndicator, TagsCellWidget
+from utils import (
+    disposition_to_status,
+    disposition_to_color,
+    status_to_color,
+    clean_phone_number,
+)
 
 
 class ContactsTableWidget(QWidget):
@@ -68,6 +74,22 @@ class ContactsTableWidget(QWidget):
         self._load_layout()
         self._setup_ui()
         self.load_contacts()
+
+    def _set_disposition_style(self, combo: QComboBox, disposition: str):
+        """Apply background color to the disposition combo box."""
+        color = disposition_to_color(disposition)
+        if color:
+            combo.setStyleSheet(f"QComboBox{{background-color: {color};}}")
+        else:
+            combo.setStyleSheet("")
+
+    def _set_status_style(self, combo: QComboBox, status: str):
+        """Apply background color to the status combo box."""
+        color = status_to_color(status)
+        if color:
+            combo.setStyleSheet(f"QComboBox{{background-color: {color};}}")
+        else:
+            combo.setStyleSheet("")
 
     def _setup_ui(self):
         layout = QVBoxLayout(self)
@@ -162,9 +184,14 @@ class ContactsTableWidget(QWidget):
                         "wrong_company",
                     ]
                     combo.addItems(dispositions)
-                    combo.setCurrentText(contact.get("contact_disposition", ""))
+                    current_disp = contact.get("contact_disposition", "")
+                    combo.setCurrentText(current_disp)
+                    self._set_disposition_style(combo, current_disp)
                     combo.currentTextChanged.connect(
-                        lambda value, cid=contact.get("profile_id"): self._on_disposition_changed(cid, value)
+                        lambda value, cid=contact.get("profile_id"), c=combo: (
+                            self._on_disposition_changed(cid, value),
+                            self._set_disposition_style(c, value),
+                        )
                     )
                     self.table.setCellWidget(row, col, combo)
                 elif header == "tags":
@@ -177,9 +204,14 @@ class ContactsTableWidget(QWidget):
                 elif header == "status":
                     combo = QComboBox()
                     combo.addItems(["active", "inactive"])
-                    combo.setCurrentText(contact.get("status", ""))
+                    current_status = contact.get("status", "")
+                    combo.setCurrentText(current_status)
+                    self._set_status_style(combo, current_status)
                     combo.currentTextChanged.connect(
-                        lambda value, cid=contact.get("profile_id"): self._on_status_changed(cid, value)
+                        lambda value, cid=contact.get("profile_id"), c=combo: (
+                            self._on_status_changed(cid, value),
+                            self._set_status_style(c, value),
+                        )
                     )
                     self.table.setCellWidget(row, col, combo)
                 elif header in ["website", "personal_linkedin_url"]:
@@ -194,6 +226,11 @@ class ContactsTableWidget(QWidget):
                         self.table.setCellWidget(row, col, label)
                     else:
                         self.table.setItem(row, col, QTableWidgetItem(""))
+                elif header == "mobile":
+                    value = clean_phone_number(str(contact.get("mobile", "")))
+                    item = QTableWidgetItem(value)
+                    item.setFlags(Qt.ItemIsSelectable | Qt.ItemIsEnabled)
+                    self.table.setItem(row, col, item)
                 else:
                     value = str(contact.get(header, ""))
                     item = QTableWidgetItem(value)
@@ -246,8 +283,6 @@ class ContactsTableWidget(QWidget):
     def _on_disposition_changed(self, contact_id, disposition):
         if not contact_id:
             return
-        from utils import disposition_to_status
-
         status = disposition_to_status(disposition)
         self.db.update_contact(
             contact_id,

--- a/utils.py
+++ b/utils.py
@@ -11,10 +11,54 @@ INACTIVE_DISPOSITIONS = {
     "connected_positive",
 }
 
+# Soft highlight colors used for dispositions and status values. The colors are
+# semi-transparent so that text remains readable and the UI isn't overpowered.
+DISPOSITION_COLORS = {
+    "connected_positive": "rgba(144, 238, 144, 0.4)",  # light green
+    "connected_meeting_booked": "rgba(144, 238, 144, 0.4)",
+    "connected_neutral": "rgba(255, 255, 128, 0.4)",  # light yellow
+    "number_validated": "rgba(255, 255, 128, 0.4)",
+    "left_voicemail": "rgba(255, 255, 128, 0.4)",
+    "referred_to_another_contact": "rgba(255, 255, 128, 0.4)",
+    "busy_call_back_later": "rgba(255, 255, 128, 0.4)",
+    "connected_negative": "rgba(255, 182, 193, 0.4)",  # light red
+    "wrong_number": "rgba(255, 182, 193, 0.4)",
+    "not_in_service": "rgba(255, 182, 193, 0.4)",
+    "do_not_call": "rgba(255, 182, 193, 0.4)",
+    "unreachable": "rgba(255, 182, 193, 0.4)",
+    "wrong_company": "rgba(255, 182, 193, 0.4)",
+}
+
+# Status column highlight colors
+STATUS_COLORS = {
+    "active": "rgba(144, 238, 144, 0.4)",
+    "inactive": "rgba(255, 182, 193, 0.4)",
+}
+
+
+def clean_phone_number(number: str) -> str:
+    """Return a phone number stripped of extra whitespace and symbols."""
+    import re
+
+    cleaned = re.sub(r"[^\d+]+", "", number or "")
+    if cleaned.startswith("+"):
+        return "+" + cleaned[1:].replace("+", "")
+    return cleaned.replace("+", "")
+
 
 def disposition_to_status(disposition: str) -> str:
     """Return the status string for a given contact disposition."""
     if not disposition:
         disposition = "not_defined"
     return "inactive" if disposition in INACTIVE_DISPOSITIONS else "active"
+
+
+def disposition_to_color(disposition: str) -> str:
+    """Return the highlight color for a given disposition."""
+    return DISPOSITION_COLORS.get(disposition, "")
+
+
+def status_to_color(status: str) -> str:
+    """Return the highlight color for a status value."""
+    return STATUS_COLORS.get(status, "")
 


### PR DESCRIPTION
## Summary
- highlight disposition and status cells with soft colors
- centralize color mappings in `utils.py`
- clean up phone numbers when displaying mobile numbers

## Testing
- `python -m py_compile utils.py ui/contacts_table.py`


------
https://chatgpt.com/codex/tasks/task_e_685813acd028833292a2355f37338a00