### PR TITLE
Add company alias enrichment

### DIFF
--- a/ai/enrichment.py
+++ b/ai/enrichment.py
@@ -11,6 +11,7 @@ AI_FIELDS = [
     "area_of_business",
     "most_relevant_summit",
     "client_icp",
+    "company_alias",
     "time_zone_utc",
 ]
 
@@ -125,6 +126,24 @@ def enrich_database(
                             status_callback(str(exc))
                         step += 1
                         progress_callback(step, total)
+                if not c.get("company_alias"):
+                    try:
+                        result = run_prompt(
+                            "company_alias",
+                            {
+                                "company_name": c.get("company_name", ""),
+                                "company_description": c.get(
+                                    "company_description", ""
+                                ),
+                            },
+                        )
+                        db.update_contact(
+                            c["profile_id"], {"company_alias": result}
+                        )
+                    except Exception as exc:  # noqa: BLE001
+                        status_callback(str(exc))
+                    step += 1
+                    progress_callback(step, total)
                 if not c.get("time_zone_utc"):
                     try:
                         result = lookup_utc_offset(

--- a/config/settings.py
+++ b/config/settings.py
@@ -16,6 +16,7 @@ DEFAULT_SETTINGS = {
         "area_of_business": "",
         "most_relevant_summit": "",
         "client_icp": "",
+        "company_alias": "",
     },
     "timezone": {
         "utc_offset": 0,

--- a/db_manager.py
+++ b/db_manager.py
@@ -117,6 +117,7 @@ class DBManager:
             "area_of_business": "TEXT",
             "most_relevant_summit": "TEXT",
             "client_icp": "TEXT",
+            "company_alias": "TEXT",
             "tags": "TEXT",
             "added_timestamp": "TEXT",
             "status": "TEXT",

--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -37,6 +37,7 @@ class ContactsTableWidget(QWidget):
         "last_name",
         "email",
         "company_name",
+        "company_alias",
         "website",
         "country",
         "state",
@@ -242,6 +243,7 @@ class ContactsTableWidget(QWidget):
                         "area_of_business",
                         "most_relevant_summit",
                         "client_icp",
+                        "company_alias",
                         "time_zone_utc",
                     ]:
                         flags |= Qt.ItemIsEditable
@@ -268,6 +270,7 @@ class ContactsTableWidget(QWidget):
             "area_of_business",
             "most_relevant_summit",
             "client_icp",
+            "company_alias",
             "time_zone_utc",
         }
         if header not in editable:

--- a/ui/settings_panel.py
+++ b/ui/settings_panel.py
@@ -71,6 +71,7 @@ class SettingsDialog(QDialog):
             ("area_of_business", "Area of Business"),
             ("most_relevant_summit", "Most Relevant Summit"),
             ("client_icp", "ICP of the Client"),
+            ("company_alias", "Company Alias"),
         ]
         for key, label in prompts:
             edit = QPlainTextEdit(psettings.get(key, ""))


### PR DESCRIPTION
## Summary
- enrich contacts with new `company_alias` field
- store a new Company Alias prompt in settings
- expose the field in the contacts table
- allow editing the field from the table

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685818bfa5388332bccd188329a0a001