### PR TITLE
Implement fixed company_alias prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Available models you can select are:
 - `o3-mini`
 
 Use only the base model name (e.g. `"gpt-4.1"`) without any date suffixes.
+
+The company alias field is always generated automatically during enrichment.
+The application uses a fixed prompt that cannot be customized to produce a
+short, conversational version of the company name when the alias field is empty.

--- a/ai/llm_manager.py
+++ b/ai/llm_manager.py
@@ -2,6 +2,18 @@ from openai import OpenAI
 from config.settings import get_settings
 
 
+COMPANY_ALIAS_PROMPT = (
+    "Here is the official company name:\n"
+    "{company_name}\n"
+    "Your task is to return ONLY the short, conversational, or common alias people use to refer to this company.\n"
+    "If the name is \u201cThe Walt Disney Company\u201d, return \u201cDisney\u201d.\n"
+    "If the name is \u201cA.A. Monkey LLC\u201d, return \u201cA.A. Monkey\u201d.\n"
+    "If the name is \u201cPinocho Company by T-Mobile\u201d, return \u201cPinocho\u201d.\n"
+    "If there is no obvious alias, just return the most natural main part of the name.\n"
+    "Output ONLY the alias, with no extra text, formatting, or explanation."
+)
+
+
 def _get_openai_config():
     settings = get_settings()
     return settings.get("openai_api_key"), settings.get("llm_model"), settings.get("prompts", {})
@@ -13,6 +25,8 @@ def is_configured() -> bool:
 
 
 def get_prompt(name: str) -> str:
+    if name == "company_alias":
+        return COMPANY_ALIAS_PROMPT
     _api, _model, prompts = _get_openai_config()
     return prompts.get(name, "")
 
@@ -21,9 +35,12 @@ def run_prompt(prompt_name: str, variables: dict | None = None, clean: bool = Tr
     api_key, model, prompts = _get_openai_config()
     if not api_key or not model:
         raise RuntimeError("OpenAI API key or model not configured")
-    template = prompts.get(prompt_name)
-    if not template:
-        raise RuntimeError(f"Prompt template '{prompt_name}' not configured")
+    if prompt_name == "company_alias":
+        template = COMPANY_ALIAS_PROMPT
+    else:
+        template = prompts.get(prompt_name)
+        if not template:
+            raise RuntimeError(f"Prompt template '{prompt_name}' not configured")
     variables = variables or {}
 
     # Format the user's template with the given variables

--- a/config/settings.py
+++ b/config/settings.py
@@ -16,7 +16,6 @@ DEFAULT_SETTINGS = {
         "area_of_business": "",
         "most_relevant_summit": "",
         "client_icp": "",
-        "company_alias": "",
     },
     "timezone": {
         "utc_offset": 0,

--- a/csv_importer.py
+++ b/csv_importer.py
@@ -41,6 +41,8 @@ class CSVImporter:
                 if not any(cell.strip() for cell in row):
                     continue
                 data = dict(zip(mapped_headers, row))
+                # Ensure company_alias starts empty on import
+                data["company_alias"] = ""
                 if not data.get("added_timestamp"):
                     data["added_timestamp"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                 self.db_manager.insert_contact(data)

--- a/ui/settings_panel.py
+++ b/ui/settings_panel.py
@@ -71,7 +71,6 @@ class SettingsDialog(QDialog):
             ("area_of_business", "Area of Business"),
             ("most_relevant_summit", "Most Relevant Summit"),
             ("client_icp", "ICP of the Client"),
-            ("company_alias", "Company Alias"),
         ]
         for key, label in prompts:
             edit = QPlainTextEdit(psettings.get(key, ""))


### PR DESCRIPTION
## Summary
- keep company_alias prompt internal and remove it from settings
- remove company_alias editing from Settings dialog
- ensure imported contacts start with an empty company_alias
- add hardcoded prompt logic for company_alias LLM calls
- document automatic company alias generation

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68581c85a0108332b4eb0ba0a687ddfd