### PR TITLE
Simplify CSV export workflow

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -27,6 +27,7 @@ DEFAULT_SETTINGS = {
         "visibility": {},
         "widths": {},
     },
+    "export_fields": [],
 }
 
 _settings = None

--- a/exporter.py
+++ b/exporter.py
@@ -27,10 +27,9 @@ def export_contacts(
     contacts: List[dict],
     headers: List[str],
     export_dir: str,
-    base_name: str,
     groups: int = 1,
     split_by_tz: bool = False,
-) -> Tuple[int, int]:
+) -> int:
     """Export contacts to CSV files.
 
     Parameters
@@ -40,26 +39,24 @@ def export_contacts(
     headers : list of str
         Visible headers in the current table.
     export_dir : str
-        Target directory where the folder will be created.
-    base_name : str
-        Base name for each CSV file.
+        Target directory where CSV files will be written.
     groups : int, optional
         How many groups/chunks each time zone should be split into.
     split_by_tz : bool, optional
-        Whether to create separate folders/files per time zone.
+        Whether to create separate files for each time zone.
 
     Returns
     -------
-    tuple
-        Number of files created and number of folders created (including the
-        main folder).
+    int
+        Number of CSV files created.
     """
     os.makedirs(export_dir, exist_ok=True)
 
-    header_row = [_snake_case("phone_number" if h == "mobile" else h) for h in headers]
+    header_row = ["mobile_phone"] + [
+        _snake_case(h) for h in headers if h != "mobile"
+    ]
 
     file_count = 0
-    folder_count = 1  # main folder
 
     if split_by_tz:
         tz_groups: Dict[Optional[str], List[dict]] = {}
@@ -72,30 +69,29 @@ def export_contacts(
     for tz, clist in tz_groups.items():
         if not clist:
             continue
-        tz_dir = export_dir
         tz_suffix = ""
+        morning, afternoon = "NA", "NA"
         if split_by_tz:
             morning, afternoon = _calculate_call_times(tz)
             tz_suffix = f"{morning.replace(':', '_')}-{afternoon.replace(':', '_')}"
-            tz_dir = os.path.join(export_dir, tz_suffix)
-            os.makedirs(tz_dir, exist_ok=True)
-            folder_count += 1
 
         chunks = _chunk_list(clist, groups)
         for idx, chunk in enumerate(chunks):
             if not chunk:
                 continue
             group_name = f"Group_{chr(ord('A') + idx)}"
-            parts = [base_name, group_name]
+            parts = [group_name]
             if split_by_tz:
                 parts.append(tz_suffix)
             filename = "_".join(parts) + ".csv"
-            path = os.path.join(tz_dir, filename)
+            path = os.path.join(export_dir, filename)
             with open(path, "w", newline="", encoding="utf-8") as f:
                 writer = csv.writer(f)
                 writer.writerow(header_row)
                 for contact in chunk:
-                    writer.writerow([contact.get(h, "") for h in headers])
+                    row = [contact.get("mobile", "")]
+                    row += [contact.get(h, "") for h in headers if h != "mobile"]
+                    writer.writerow(row)
             file_count += 1
 
-    return file_count, folder_count
+    return file_count

--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -20,7 +20,7 @@ from PyQt5.QtCore import Qt, QPoint
 import os
 
 from db_manager import DBManager
-from config.settings import get_settings, save_settings
+from config.settings import get_settings, save_settings, update_setting
 from ui.filter_popup import FilterPopup
 from ui.filter_header import FilterHeader
 from ui.tag_tools import TagSelectionDialog, ModeIndicator, TagsCellWidget
@@ -563,30 +563,32 @@ class ContactsTableWidget(QWidget):
 
     def export_view(self):
         """Export the currently visible contacts to CSV."""
-        dialog = ExportOptionsDialog(self)
+        settings = get_settings()
+        selected = settings.get("export_fields", self.HEADERS)
+        dialog = ExportOptionsDialog(self.HEADERS, selected, self)
         if dialog.exec() != QDialog.Accepted:
             return
-        folder, base, split_by_tz, groups = dialog.options()
-        if not folder or not base:
-            QMessageBox.warning(self, "Export", "Folder and base file names are required")
+        folder, split_by_tz, groups, fields = dialog.options()
+        if not folder:
+            QMessageBox.warning(self, "Export", "Folder name is required")
             return
+        update_setting("export_fields", fields)
         target_dir = QFileDialog.getExistingDirectory(self, "Select Export Directory")
         if not target_dir:
             return
         export_path = os.path.join(target_dir, folder)
-        headers = [h for h in self.HEADERS if self.column_visibility.get(h, True)]
-        files, folders = export_contacts(
+        headers = [h for h in fields if self.column_visibility.get(h, True)]
+        files = export_contacts(
             self.filtered_contacts,
             headers,
             export_path,
-            base,
             groups,
             split_by_tz,
         )
         QMessageBox.information(
             self,
             "Export Complete",
-            f"Created {files} file(s) in {folders} folder(s) at {export_path}",
+            f"Created {files} file(s) in {export_path}",
         )
         self._status_callback("Export completed")
 

--- a/ui/export_dialog.py
+++ b/ui/export_dialog.py
@@ -5,23 +5,34 @@ from PyQt5.QtWidgets import (
     QLineEdit,
     QSpinBox,
     QCheckBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+    QStackedLayout,
 )
-from typing import Tuple
+from typing import List, Tuple
 
 
 class ExportOptionsDialog(QDialog):
     """Dialog to configure export options."""
 
-    def __init__(self, parent=None):
+    def __init__(self, headers: List[str], selected: List[str], parent=None):
         super().__init__(parent)
         self.setWindowTitle("Export View")
-        form = QFormLayout(self)
+        self._headers = headers
+        self._selected = set(selected)
+
+        self._stack = QStackedLayout(self)
+        self._build_main_page()
+        self._build_fields_page()
+        self._stack.setCurrentIndex(0)
+
+    def _build_main_page(self):
+        page = QWidget()
+        form = QFormLayout(page)
 
         self.folder_edit = QLineEdit()
         form.addRow("Folder Name", self.folder_edit)
-
-        self.base_edit = QLineEdit()
-        form.addRow("Base File Name", self.base_edit)
 
         self.tz_split = QCheckBox("Split by time zone")
         form.addRow(self.tz_split)
@@ -31,15 +42,43 @@ class ExportOptionsDialog(QDialog):
         self.group_spin.setValue(1)
         form.addRow("Number of groups", self.group_spin)
 
+        field_btn = QPushButton("Select Fields")
+        field_btn.clicked.connect(lambda: self._stack.setCurrentIndex(1))
+        form.addRow(field_btn)
+
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
         form.addWidget(buttons)
 
-    def options(self) -> Tuple[str, str, bool, int]:
+        self._stack.addWidget(page)
+
+    def _build_fields_page(self):
+        page = QWidget()
+        layout = QVBoxLayout(page)
+        self.field_checks = {}
+        for header in self._headers:
+            cb = QCheckBox(header)
+            if header == "mobile":
+                cb.setChecked(True)
+                cb.setEnabled(False)
+            else:
+                cb.setChecked(header in self._selected)
+            layout.addWidget(cb)
+            self.field_checks[header] = cb
+
+        back_btn = QPushButton("Back")
+        back_btn.clicked.connect(lambda: self._stack.setCurrentIndex(0))
+        layout.addWidget(back_btn)
+        self._stack.addWidget(page)
+
+    def options(self) -> Tuple[str, bool, int, List[str]]:
+        fields = [
+            h for h, cb in self.field_checks.items() if cb.isChecked()
+        ]
         return (
             self.folder_edit.text().strip(),
-            self.base_edit.text().strip(),
             self.tz_split.isChecked(),
             self.group_spin.value(),
+            fields,
         )


### PR DESCRIPTION
## Summary
- keep list of export fields in settings
- write CSV files directly in one folder
- add column selection in the export dialog
- use a single dialog for export options and field selection
- update ContactsTable export logic accordingly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858210168e883328d675a6ee9a06dee