### PR TITLE
Fix settings serialization for filter sets

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -46,6 +46,7 @@ def load_settings():
         _settings = DEFAULT_SETTINGS.copy()
     # Ensure all keys exist
     _merge_defaults(_settings, DEFAULT_SETTINGS)
+    _deserialize_sets(_settings)
     return _settings
 
 
@@ -55,7 +56,7 @@ def save_settings():
         return
     CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
     with open(CONFIG_FILE, "w", encoding="utf-8") as f:
-        json.dump(_settings, f, indent=2)
+        json.dump(_serialize_sets(_settings), f, indent=2)
 
 
 def get_settings():
@@ -83,6 +84,24 @@ def _merge_defaults(target, defaults):
             _merge_defaults(target[key], val)
         else:
             target.setdefault(key, val)
+
+
+def _serialize_sets(obj):
+    """Recursively convert sets in the settings to lists for JSON."""
+    if isinstance(obj, dict):
+        return {k: _serialize_sets(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_serialize_sets(v) for v in obj]
+    if isinstance(obj, set):
+        return list(obj)
+    return obj
+
+
+def _deserialize_sets(obj):
+    """Convert lists back to sets for known set-containing fields."""
+    table_filters = obj.get("table_filters")
+    if isinstance(table_filters, dict):
+        obj["table_filters"] = {k: set(v) for k, v in table_filters.items()}
 
 # Load settings on import
 load_settings()

--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -514,7 +514,10 @@ class ContactsTableWidget(QWidget):
         self.column_visibility.update(settings.get("visibility", {}))
         self.column_order = settings.get("order", self.HEADERS[:])
         self.column_widths = settings.get("widths", {})
-        self.filters = get_settings().get("table_filters", {})
+        raw_filters = get_settings().get("table_filters", {})
+        self.filters = {
+            k: set(v) if not isinstance(v, set) else v for k, v in raw_filters.items()
+        }
         sort = get_settings().get("table_sort", {})
         column = sort.get("column")
         if column in self.HEADERS:


### PR DESCRIPTION
## Summary
- handle sets when saving/loading configuration
- normalize saved filter data in ContactsTable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b915e0788332a5234a7fc5215c3b