### PR TITLE
Fix export header

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,7 @@ Use only the base model name (e.g. `"gpt-4.1"`) without any date suffixes.
 The company alias field is always generated automatically during enrichment.
 The application uses a fixed prompt that cannot be customized to produce a
 short, conversational version of the company name when the alias field is empty.
+
+## CSV Export
+
+When exporting contacts to CSV, the first column contains phone numbers and is labeled `phone_number` in the header. Remaining fields use snake_case headers derived from the table columns.

--- a/exporter.py
+++ b/exporter.py
@@ -62,7 +62,7 @@ def export_contacts(
     """
     os.makedirs(export_dir, exist_ok=True)
 
-    header_row = ["mobile_phone"] + [
+    header_row = ["phone_number"] + [
         _snake_case(h) for h in headers if h != "mobile"
     ]
 


### PR DESCRIPTION
## Summary
- label CSV phone column as `phone_number`
- document CSV export headers in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858c3a005b88332a25883521f27e0c2