### PR TITLE
Fix status/disposition dropdowns not updating

### DIFF
--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -178,7 +178,7 @@ class ContactsTableWidget(QWidget):
                     current_disp = contact.get("contact_disposition", "")
                     combo.setCurrentText(current_disp)
                     self._set_disposition_style(combo, current_disp)
-                    combo.currentTextChanged.connect(
+                    combo.currentIndexChanged[str].connect(
                         lambda value, cid=contact.get("profile_id"), c=combo: (
                             self._on_disposition_changed(cid, value),
                             self._set_disposition_style(c, value),
@@ -198,7 +198,7 @@ class ContactsTableWidget(QWidget):
                     current_status = contact.get("status", "")
                     combo.setCurrentText(current_status)
                     self._set_status_style(combo, current_status)
-                    combo.currentTextChanged.connect(
+                    combo.currentIndexChanged[str].connect(
                         lambda value, cid=contact.get("profile_id"), c=combo: (
                             self._on_status_changed(cid, value),
                             self._set_status_style(c, value),

--- a/ui/settings_panel.py
+++ b/ui/settings_panel.py
@@ -52,7 +52,7 @@ class SettingsDialog(QDialog):
             "o3-mini",
         ])
         self.model_combo.setCurrentText(self._settings.get("llm_model", "gpt-4.1"))
-        self.model_combo.currentTextChanged.connect(
+        self.model_combo.currentIndexChanged[str].connect(
             lambda text: update_setting("llm_model", text)
         )
         form.addRow("LLM Model", self.model_combo)


### PR DESCRIPTION
## Summary
- fix call disposition and status dropdown signals
- ensure settings dialog uses a compatible combobox signal

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6859af6fcafc833290d57fd8c2cfcd12