### PR TITLE
Handle empty filter lists

### DIFF
--- a/db_manager.py
+++ b/db_manager.py
@@ -321,6 +321,8 @@ class DBManager:
                         raise ValueError(f"Invalid column name: {column}")
                     ph = "%s" if self.use_postgres else "?"
                     if isinstance(value, (list, tuple, set)):
+                        if len(value) == 0:
+                            continue
                         ph_list = ",".join([ph] * len(value))
                         clauses.append(f'"{column}" IN ({ph_list})')
                         params.extend(list(value))

--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -494,7 +494,9 @@ class ContactsTableWidget(QWidget):
         self.column_widths = settings.get("widths", {})
         raw_filters = get_settings().get("table_filters", {})
         self.filters = {
-            k: set(v) if not isinstance(v, set) else v for k, v in raw_filters.items()
+            k: set(v) if not isinstance(v, set) else v
+            for k, v in raw_filters.items()
+            if v
         }
         sort = get_settings().get("table_sort", {})
         column = sort.get("column")
@@ -532,7 +534,7 @@ class ContactsTableWidget(QWidget):
             "visibility": self.column_visibility,
             "widths": widths,
         }
-        settings["table_filters"] = self.filters
+        settings["table_filters"] = {k: v for k, v in self.filters.items() if v}
         sort = {}
         if self.sort_column is not None:
             sort = {


### PR DESCRIPTION
## Summary
- skip empty lists when building fallback SQL filters
- ignore empty filters when loading layout
- omit empty filters when saving layout

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6859c068cd408332af75532b1cd041a5