### PR TITLE
Add pagination and page size controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A small demo application for importing Cognism CSV files into a SQLite database 
 * **ui/settings_panel.py** – user interface for editing API keys, prompt templates and time zone options.
 * **config/settings.py** – loads and saves persistent configuration in the user's home directory.
 * **main.py** – launches the application window and wires up the components. All actions are available from a hamburger menu in the header, including a **Settings** option for configuration.
+* Supports paginated views with a configurable page size so exports only include the currently visible contacts.
 
 Import contacts by creating a `CSVImporter` instance pointing to your CSV file and calling `import_contacts()` or using the **Import CSV** button in the GUI.
 
@@ -46,6 +47,7 @@ short, conversational version of the company name when the alias field is empty.
 ## CSV Export
 
 When exporting contacts to CSV, the first column contains phone numbers and is labeled `phone_number` in the header. Remaining fields use snake_case headers derived from the table columns.
+Only the contacts visible on the current page are exported when pagination is enabled.
 
 ## PostgreSQL Setup
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -28,6 +28,7 @@ DEFAULT_SETTINGS = {
         "widths": {},
     },
     "export_fields": [],
+    "page_size": 50,
 }
 
 _settings = None

--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -1,6 +1,7 @@
 from PyQt5.QtWidgets import (
     QWidget,
     QVBoxLayout,
+    QHBoxLayout,
     QTableWidget,
     QTableWidgetItem,
     QComboBox,
@@ -10,6 +11,8 @@ from PyQt5.QtWidgets import (
     QDialogButtonBox,
     QFormLayout,
     QLabel,
+    QPushButton,
+    QSpinBox,
     QApplication,
     QFileDialog,
     QMessageBox,
@@ -78,6 +81,10 @@ class ContactsTableWidget(QWidget):
         self.quick_mode = None
         self.quick_tag = ""
         self.session_tags = set()
+        settings = get_settings()
+        self.page_size = int(settings.get("page_size", 50))
+        self.page = 0
+        self._has_next = False
         self._load_layout()
         self._setup_ui()
         self.load_contacts()
@@ -125,13 +132,33 @@ class ContactsTableWidget(QWidget):
         self.table.cellClicked.connect(self._on_cell_clicked)
         layout.addWidget(self.table)
 
+        nav = QHBoxLayout()
+        self.prev_btn = QPushButton("Previous")
+        self.next_btn = QPushButton("Next")
+        self.page_label = QLabel()
+        self.page_size_spin = QSpinBox()
+        self.page_size_spin.setRange(1, 1000)
+        self.page_size_spin.setValue(self.page_size)
+        self.prev_btn.clicked.connect(lambda: self._change_page(-1))
+        self.next_btn.clicked.connect(lambda: self._change_page(1))
+        self.page_size_spin.editingFinished.connect(self._on_page_size_changed)
+        nav.addWidget(self.prev_btn)
+        nav.addWidget(self.next_btn)
+        nav.addWidget(self.page_label)
+        nav.addStretch(1)
+        nav.addWidget(QLabel("Page Size:"))
+        nav.addWidget(self.page_size_spin)
+        layout.addLayout(nav)
+
         self._apply_layout()
 
     def load_contacts(self):
+        self.page = 0
         self._apply_filters()
 
     def set_search_text(self, text: str):
         self.search_text = text
+        self.page = 0
         self._apply_filters()
 
 
@@ -141,13 +168,20 @@ class ContactsTableWidget(QWidget):
             sort_by = self.HEADERS[self.sort_column]
         sort_order = "desc" if self.sort_order == Qt.DescendingOrder else "asc"
         filters = {k: list(v) for k, v in self.filters.items()}
-        self.contacts = self.db.fetch_contacts(
+        contacts = self.db.fetch_contacts(
             filters=filters,
             search=self.search_text,
             sort_by=sort_by,
             sort_order=sort_order,
+            limit=self.page_size + 1,
+            offset=self.page * self.page_size,
         )
+        self._has_next = len(contacts) > self.page_size
+        self.contacts = contacts[: self.page_size]
         self._show_contacts(self.contacts)
+        self.prev_btn.setEnabled(self.page > 0)
+        self.next_btn.setEnabled(self._has_next)
+        self.page_label.setText(f"Page {self.page + 1}")
 
     def _show_contacts(self, contacts):
         self.filtered_contacts = contacts
@@ -421,6 +455,7 @@ class ContactsTableWidget(QWidget):
         else:
             self.filters[field] = selected
         self._update_header_styles()
+        self.page = 0
         self._apply_filters()
         self.save_layout()
 
@@ -428,6 +463,7 @@ class ContactsTableWidget(QWidget):
         self.sort_column = column
         self.sort_order = order
         popup.hide()
+        self.page = 0
         self._apply_filters()
         self.save_layout()
 
@@ -479,6 +515,24 @@ class ContactsTableWidget(QWidget):
         self._apply_filters()
         self.table.verticalScrollBar().setValue(scroll)
         self._status_callback("Tag removed")
+
+    def _change_page(self, delta: int):
+        new_page = self.page + delta
+        if new_page < 0:
+            return
+        if delta > 0 and not self._has_next:
+            return
+        self.page = new_page
+        self._apply_filters()
+
+    def _on_page_size_changed(self):
+        size = self.page_size_spin.value()
+        if size <= 0:
+            return
+        self.page_size = size
+        update_setting("page_size", size)
+        self.page = 0
+        self._apply_filters()
 
     def _load_layout(self):
         settings = get_settings().get("table_layout", {})


### PR DESCRIPTION
## Summary
- allow configurable page size in settings
- show pagination controls with prev/next buttons
- only export contacts visible on the current page

## Testing
- `python -m py_compile ui/contacts_table.py config/settings.py`

------
https://chatgpt.com/codex/tasks/task_e_685ca853a4408332be878aa32eb0e959