### PR TITLE
Fix call time calculation and ensure columns exist

### DIFF
--- a/ai/enrichment.py
+++ b/ai/enrichment.py
@@ -33,7 +33,7 @@ def _calculate_call_times(offset: str) -> tuple[str, str]:
     except (TypeError, ValueError):
         return "NA", "NA"
 
-    diff = contact_offset - user_offset
+    diff = user_offset - contact_offset
     return _shift_time(morning, diff), _shift_time(afternoon, diff)
 
 

--- a/db_manager.py
+++ b/db_manager.py
@@ -302,6 +302,11 @@ class DBManager:
     ):
         """Fetch contacts via the Go API backend."""
 
+        # Ensure the contacts table exists with all expected columns before
+        # delegating to the Go service. Without this the table may lack newer
+        # columns when the backend created it earlier.
+        self.create_contacts_table()
+
         payload = {
             "filters": filters or {},
             "search": search or "",


### PR DESCRIPTION
## Summary
- ensure the contacts table schema is created before the Go backend query
- compute morning/afternoon call times relative to the user's timezone

## Testing
- `python -m py_compile ai/enrichment.py db_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_685cb8c06d5883328f5a0daac9129cbe