### PR TITLE
Fix hidden columns not appearing

### DIFF
--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -417,6 +417,7 @@ class ContactsTableWidget(QWidget):
                 self.column_visibility[header] = cb.isChecked()
             for idx, header in enumerate(self.HEADERS):
                 self.table.setColumnHidden(idx, not self.column_visibility[header])
+            self.table.resizeColumnsToContents()
             self._status_callback("Column visibility updated")
             self.save_layout()
 
@@ -565,6 +566,8 @@ class ContactsTableWidget(QWidget):
             self.table.setColumnHidden(idx, not self.column_visibility.get(name, True))
             if name in getattr(self, "column_widths", {}):
                 header.resizeSection(idx, self.column_widths[name])
+            else:
+                header.resizeSection(idx, header.sectionSizeHint(idx))
         self._update_header_styles()
 
     def save_layout(self):


### PR DESCRIPTION
## Summary
- ensure visible columns are resized when toggled on
- assign a reasonable width for columns that lack saved widths

## Testing
- `python -m py_compile ui/contacts_table.py`
- `python -m py_compile $(git ls-files '*.py')`
- `cd go_backend && go vet ./...` *(fails: missing go.sum entry)*

------
https://chatgpt.com/codex/tasks/task_e_685d1813a2b88332a8081c4e24e72dc5