### PR TITLE
Fix tag-based filtering

### DIFF
--- a/db_manager.py
+++ b/db_manager.py
@@ -348,15 +348,33 @@ class DBManager:
                     if column not in valid_columns:
                         raise ValueError(f"Invalid column name: {column}")
                     ph = "%s" if self.use_postgres else "?"
-                    if isinstance(value, (list, tuple, set)):
-                        if len(value) == 0:
-                            continue
-                        ph_list = ",".join([ph] * len(value))
-                        clauses.append(f'"{column}" IN ({ph_list})')
-                        params.extend(list(value))
+                    values = value if isinstance(value, (list, tuple, set)) else [value]
+                    if not values:
+                        continue
+                    if column == "tags":
+                        tag_clauses = []
+                        for tag in values:
+                            if not tag:
+                                tag_clauses.append('(\"tags\" = "" OR \"tags\" IS NULL)')
+                                continue
+                            tag_clauses.append(
+                                f'(\"tags\" = {ph} OR \"tags\" LIKE {ph} OR \"tags\" LIKE {ph} OR \"tags\" LIKE {ph})'
+                            )
+                            params.extend([
+                                tag,
+                                f"{tag},%",
+                                f"%,{tag}",
+                                f"%,{tag},%",
+                            ])
+                        clauses.append("(" + " OR ".join(tag_clauses) + ")")
                     else:
-                        clauses.append(f'"{column}" = {ph}')
-                        params.append(value)
+                        if len(values) > 1:
+                            ph_list = ",".join([ph] * len(values))
+                            clauses.append(f'"{column}" IN ({ph_list})')
+                            params.extend(list(values))
+                        else:
+                            clauses.append(f'"{column}" = {ph}')
+                            params.append(values[0])
 
             if search:
                 search_columns = [

--- a/go_backend/main.go
+++ b/go_backend/main.go
@@ -101,6 +101,23 @@ func fetchContacts(db *sql.DB, req *QueryRequest) ([]map[string]any, error) {
 		if len(values) == 0 {
 			continue
 		}
+		if col == "tags" {
+			tagParts := make([]string, 0, len(values))
+			for _, v := range values {
+				if v == "" {
+					tagParts = append(tagParts, "(\"tags\" = '' OR \"tags\" IS NULL)")
+					continue
+				}
+				p1, p2, p3, p4 := nextPH(), nextPH(), nextPH(), nextPH()
+				params = append(params, v, v+",%", "%,"+v, "%,"+v+",%")
+				tagParts = append(tagParts,
+					fmt.Sprintf("(\"tags\" = %s OR \"tags\" LIKE %s OR \"tags\" LIKE %s OR \"tags\" LIKE %s)", p1, p2, p3, p4))
+			}
+			if len(tagParts) > 0 {
+				clauses = append(clauses, "("+strings.Join(tagParts, " OR ")+")")
+			}
+			continue
+		}
 		ph := make([]string, len(values))
 		for i, v := range values {
 			ph[i] = nextPH()


### PR DESCRIPTION
## Summary
- fix tag filtering logic in Python DB fallback
- implement tag filter semantics in Go backend

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `go build ./go_backend` *(fails: forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685d5bb34a1c83328140d10fbd8e03ca