### PR TITLE
Fix Quick Tag dialog to show all tags

### DIFF
--- a/db_manager.py
+++ b/db_manager.py
@@ -400,13 +400,13 @@ class DBManager:
             if sort_by:
                 sql += f' ORDER BY "{sort_by}" {"DESC" if sort_order == "desc" else "ASC"}'
 
-            if limit is not None:
+            if limit is not None and limit > 0:
                 sql += " LIMIT %s" if self.use_postgres else " LIMIT ?"
                 params.append(limit)
-                if offset is not None:
+                if offset is not None and offset > 0:
                     sql += " OFFSET %s" if self.use_postgres else " OFFSET ?"
                     params.append(offset)
-            elif offset is not None:
+            elif offset is not None and offset > 0:
                 if self.use_postgres:
                     sql += " OFFSET %s"
                 else:

--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -326,9 +326,7 @@ class ContactsTableWidget(QWidget):
 
     def _get_all_tags(self):
         tags = set(self.session_tags)
-        contacts = self.db.fetch_contacts()
-        for c in contacts:
-            tags.update(t.strip() for t in str(c.get("tags", "")).split(",") if t.strip())
+        tags.update(self.db.get_distinct_values("tags"))
         return sorted(tags)
 
     def _batch_add_tag(self):


### PR DESCRIPTION
## Summary
- ensure SQLite fallback fetches all rows when limit=0
- build Quick Tag list directly from distinct tag values

## Testing
- `python -m py_compile db_manager.py ui/contacts_table.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d6299e2788332b9a99acb85390194