### PR TITLE
Add AI Power Up per-column

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ The company alias field is always generated automatically during enrichment.
 The application uses a fixed prompt that cannot be customized to produce a
 short, conversational version of the company name when the alias field is empty.
 
+Each column filter now includes an **AI Power Up** section. Clicking **Run
+Prompt** lets you apply the configured prompt template for that column to either
+a specific number of contacts, all contacts in the current view or the entire
+database. You can choose to override existing values or only fill missing ones.
+
 ## CSV Export
 
 When exporting contacts to CSV, the first column contains phone numbers and is labeled `phone_number` in the header. Remaining fields use snake_case headers derived from the table columns.

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ from db_manager import DBManager
 from csv_importer import CSVImporter
 from ui.contacts_table import ContactsTableWidget
 from ui.settings_panel import SettingsDialog
-from ai.enrichment import enrich_database, estimate_steps
+
 
 
 class MainWindow(QMainWindow):
@@ -108,13 +108,6 @@ class MainWindow(QMainWindow):
         status_action.triggered.connect(self.table_widget._batch_set_status)
         menu.addAction(status_action)
 
-        enrich_action = QAction(
-            self.style().standardIcon(QStyle.SP_MediaPlay),
-            "Run AI Enrichment",
-            self,
-        )
-        enrich_action.triggered.connect(self._run_ai_enrichment)
-        menu.addAction(enrich_action)
 
         columns_action = QAction(
             self.style().standardIcon(QStyle.SP_FileDialogContentsView),
@@ -170,32 +163,6 @@ class MainWindow(QMainWindow):
         self.table_widget.load_contacts()
         self.show_status_message("Import completed")
 
-    def _run_ai_enrichment(self):
-        total = estimate_steps(self.db)
-        if total == 0:
-            self.show_status_message("No enrichment needed")
-            return
-        progress = QProgressDialog("Running AI enrichment...", None, 0, total, self)
-        progress.setWindowModality(Qt.WindowModal)
-        progress.setMinimumDuration(0)
-        progress.setCancelButton(None)
-        self.table_widget.setDisabled(True)
-        self.search_bar.setDisabled(True)
-
-        def _progress(step, tot):
-            progress.setMaximum(tot)
-            progress.setValue(step)
-            QApplication.processEvents()
-
-        try:
-            enrich_database(self.db, progress_callback=_progress, status_callback=self.show_status_message)
-        except Exception as exc:  # noqa: BLE001
-            self.show_status_message(str(exc), 5000)
-        finally:
-            progress.close()
-            self.table_widget.setDisabled(False)
-            self.search_bar.setDisabled(False)
-            self.table_widget.load_contacts()
 
     def closeEvent(self, event):
         self.table_widget.save_layout()

--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -16,6 +16,7 @@ from PyQt5.QtWidgets import (
     QApplication,
     QFileDialog,
     QMessageBox,
+    QProgressDialog,
 )
 from PyQt5.QtGui import QBrush
 from PyQt5.QtCore import Qt, QPoint
@@ -29,6 +30,9 @@ from ui.filter_header import FilterHeader
 from ui.tag_tools import TagSelectionDialog, ModeIndicator, TagsCellWidget
 from ui.export_dialog import ExportOptionsDialog
 from exporter import export_contacts
+from ui.power_up_dialog import PowerUpDialog
+from ai.llm_manager import run_prompt, lookup_utc_offset
+from ai.enrichment import _calculate_call_times
 from utils import (
     disposition_to_status,
     disposition_to_color,
@@ -425,7 +429,7 @@ class ContactsTableWidget(QWidget):
             return
         field = self.HEADERS[logical]
         values = self.db.get_distinct_values(field)
-        popup = FilterPopup(values, self)
+        popup = FilterPopup(values, field, self._run_ai_power_up, self)
         if field in self.filters:
             popup.set_selected(self.filters[field])
         popup.selection_changed.connect(
@@ -633,6 +637,82 @@ class ContactsTableWidget(QWidget):
             f"Created {files} file(s) in {export_path}",
         )
         self._status_callback("Export completed")
+
+    def _run_ai_power_up(self, field):
+        """Run the configured AI prompt for the given column."""
+        dialog = PowerUpDialog(self)
+        if dialog.exec() != QDialog.Accepted:
+            return
+        opts = dialog.options()
+
+        if opts["scope"] == "limit":
+            limit = opts["limit"]
+            contacts = self.db.fetch_contacts(
+                filters={k: list(v) for k, v in self.filters.items()},
+                search=self.search_text,
+                sort_by=self.HEADERS[self.sort_column] if self.sort_column is not None else "",
+                sort_order="desc" if self.sort_order == Qt.DescendingOrder else "asc",
+                limit=limit,
+            )
+        elif opts["scope"] == "view":
+            contacts = self.db.fetch_contacts(
+                filters={k: list(v) for k, v in self.filters.items()},
+                search=self.search_text,
+                sort_by=self.HEADERS[self.sort_column] if self.sort_column is not None else "",
+                sort_order="desc" if self.sort_order == Qt.DescendingOrder else "asc",
+            )
+        else:
+            contacts = self.db.fetch_contacts()
+
+        mapping = {
+            "target_company": "target_company_validation",
+            "contact_icp_status": "icp_validation",
+            "clients_of_contact": "clients_of_contact",
+            "area_of_business": "area_of_business",
+            "most_relevant_summit": "most_relevant_summit",
+            "client_icp": "client_icp",
+            "company_alias": "company_alias",
+        }
+
+        progress = QProgressDialog("Running AI Power Up...", None, 0, len(contacts), self)
+        progress.setWindowModality(Qt.WindowModal)
+        progress.setMinimumDuration(0)
+        progress.setCancelButton(None)
+
+        for step, contact in enumerate(contacts, start=1):
+            if not opts["override"] and contact.get(field):
+                progress.setValue(step)
+                QApplication.processEvents()
+                continue
+            try:
+                if field == "time_zone_utc":
+                    offset = lookup_utc_offset(
+                        contact.get("country", ""),
+                        contact.get("state", ""),
+                        contact.get("city", ""),
+                    )
+                    morning, afternoon = _calculate_call_times(offset)
+                    self.db.update_contact(
+                        contact["profile_id"],
+                        {
+                            "time_zone_utc": offset,
+                            "morning_call_time": morning,
+                            "afternoon_call_time": afternoon,
+                        },
+                    )
+                else:
+                    prompt = mapping.get(field)
+                    if prompt:
+                        result = run_prompt(prompt, contact)
+                        self.db.update_contact(contact["profile_id"], {field: result})
+            except Exception as exc:  # noqa: BLE001
+                self._status_callback(str(exc))
+            progress.setValue(step)
+            QApplication.processEvents()
+
+        progress.close()
+        self.load_contacts()
+        self._status_callback("AI Power Up completed")
 
 
 

--- a/ui/filter_popup.py
+++ b/ui/filter_popup.py
@@ -6,6 +6,7 @@ from PyQt5.QtWidgets import (
     QListWidgetItem,
     QPushButton,
     QHBoxLayout,
+    QGroupBox,
 )
 from PyQt5.QtCore import Qt, pyqtSignal
 
@@ -17,11 +18,13 @@ class FilterPopup(QWidget):
     sort_requested = pyqtSignal(Qt.SortOrder)
     closed = pyqtSignal()
 
-    def __init__(self, values, parent=None):
+    def __init__(self, values, field=None, ai_callback=None, parent=None):
         super().__init__(parent, Qt.Popup)
         self.setWindowFlags(Qt.Popup)
         self.setFocusPolicy(Qt.StrongFocus)
         self._all_values = sorted({str(v) for v in values})
+        self._field = field
+        self._ai_callback = ai_callback
         self._build_ui()
         self._populate()
 
@@ -54,6 +57,14 @@ class FilterPopup(QWidget):
         sort_row.addWidget(self.sort_asc)
         sort_row.addWidget(self.sort_desc)
         layout.addLayout(sort_row)
+
+        if self._ai_callback and self._field:
+            power_box = QGroupBox("AI Power Up")
+            power_layout = QVBoxLayout(power_box)
+            self.power_btn = QPushButton("Run Prompt")
+            self.power_btn.clicked.connect(lambda: self._ai_callback(self._field))
+            power_layout.addWidget(self.power_btn)
+            layout.addWidget(power_box)
 
     def _populate(self):
         text = self.search_edit.text().lower()

--- a/ui/power_up_dialog.py
+++ b/ui/power_up_dialog.py
@@ -1,0 +1,62 @@
+from PyQt5.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QVBoxLayout,
+    QHBoxLayout,
+    QRadioButton,
+    QSpinBox,
+    QGroupBox,
+)
+
+
+class PowerUpDialog(QDialog):
+    """Dialog to configure AI Power Up options."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("AI Power Up")
+        layout = QVBoxLayout(self)
+
+        scope_box = QGroupBox("Run for")
+        scope_layout = QVBoxLayout(scope_box)
+        self.limit_radio = QRadioButton("Specific number of contacts")
+        limit_row = QHBoxLayout()
+        limit_row.addWidget(self.limit_radio)
+        self.limit_spin = QSpinBox()
+        self.limit_spin.setRange(1, 10000)
+        self.limit_spin.setValue(10)
+        limit_row.addWidget(self.limit_spin)
+        scope_layout.addLayout(limit_row)
+        self.view_radio = QRadioButton("All contacts in this view")
+        scope_layout.addWidget(self.view_radio)
+        self.all_radio = QRadioButton("All contacts in database")
+        self.all_radio.setChecked(True)
+        scope_layout.addWidget(self.all_radio)
+        layout.addWidget(scope_box)
+
+        override_box = QGroupBox("Update mode")
+        override_layout = QVBoxLayout(override_box)
+        self.override_radio = QRadioButton("Override existing values")
+        self.empty_radio = QRadioButton("Only fill empty values")
+        self.empty_radio.setChecked(True)
+        override_layout.addWidget(self.override_radio)
+        override_layout.addWidget(self.empty_radio)
+        layout.addWidget(override_box)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def options(self):
+        if self.limit_radio.isChecked():
+            scope = "limit"
+        elif self.view_radio.isChecked():
+            scope = "view"
+        else:
+            scope = "all"
+        return {
+            "scope": scope,
+            "limit": self.limit_spin.value(),
+            "override": self.override_radio.isChecked(),
+        }


### PR DESCRIPTION
## Summary
- drop "AI Enrichment" action from the menu
- add `PowerUpDialog` for configuring prompt runs
- extend filter popup with an AI Power Up section
- implement `_run_ai_power_up` to run prompts on selected contacts
- document the new feature in the README

## Testing
- `python -m py_compile ui/power_up_dialog.py ui/filter_popup.py ui/contacts_table.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_685da3da17688332886095d5e747fbd8