### PR TITLE
Add Groq support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,31 @@ Available models you can select are:
 - `gpt-4o-mini`
 - `o3-mini`
 
+## Using Groq
+
+The application can also use Groq's Chat Completions API. Install the
+`groq` Python package and enter your Groq API key in the **Settings** dialog.
+
+```python
+from groq import Groq
+
+client = Groq()
+
+chat_completion = client.chat.completions.create(
+    model="llama-3.3-70b-versatile",
+    messages=[{"role": "user", "content": "Explain the importance of fast language models"}],
+)
+
+print(chat_completion.choices[0].message.content)
+```
+
+Available Groq models you can select are:
+
+- `gemma2-9b-it`
+- `llama-3.1-8b-instant`
+- `llama-3.3-70b-versatile`
+- `meta-llama/llama-guard-4-12b`
+
 Use only the base model name (e.g. `"gpt-4.1"`) without any date suffixes.
 
 The company alias field is always generated automatically during enrichment.
@@ -88,7 +113,7 @@ are modified:
 python update_call_times.py
 ```
 
-Use `--force-lookup` to look up missing UTC offsets via the OpenAI API before
+Use `--force-lookup` to look up missing UTC offsets via the configured LLM API before
 recomputing the call windows.
 
 ## Running the Go Backend

--- a/ai/enrichment.py
+++ b/ai/enrichment.py
@@ -62,7 +62,7 @@ def enrich_database(
     status_callback: Callable[[str], None] | None = None,
 ) -> None:
     if not is_configured():
-        raise RuntimeError("OpenAI API key or model not configured")
+        raise RuntimeError("LLM API key or model not configured")
     progress_callback = progress_callback or (lambda c, t: None)
     status_callback = status_callback or (lambda m: None)
 

--- a/ai/llm_manager.py
+++ b/ai/llm_manager.py
@@ -1,5 +1,9 @@
 from datetime import datetime
 from openai import OpenAI
+try:
+    from groq import Groq
+except Exception:  # pragma: no cover - optional dependency
+    Groq = None
 from config.settings import get_settings
 
 
@@ -15,27 +19,58 @@ COMPANY_ALIAS_PROMPT = (
 )
 
 
-def _get_openai_config():
+OPENAI_MODELS = {
+    "gpt-4.1",
+    "gpt-4.1-mini",
+    "gpt-4.1-nano",
+    "gpt-4o-mini",
+    "o3-mini",
+}
+
+GROQ_MODELS = {
+    "gemma2-9b-it",
+    "llama-3.1-8b-instant",
+    "llama-3.3-70b-versatile",
+    "meta-llama/llama-guard-4-12b",
+}
+
+
+def _get_llm_config():
     settings = get_settings()
-    return settings.get("openai_api_key"), settings.get("llm_model"), settings.get("prompts", {})
+    return (
+        settings.get("openai_api_key"),
+        settings.get("groq_api_key"),
+        settings.get("llm_model"),
+        settings.get("prompts", {}),
+    )
 
 
 def is_configured() -> bool:
-    api_key, model, _ = _get_openai_config()
-    return bool(api_key and model)
+    oa_key, groq_key, model, _ = _get_llm_config()
+    if model in GROQ_MODELS:
+        return bool(groq_key and model)
+    return bool(oa_key and model)
 
 
 def get_prompt(name: str) -> str:
     if name == "company_alias":
         return COMPANY_ALIAS_PROMPT
-    _api, _model, prompts = _get_openai_config()
+    _oa, _groq, _model, prompts = _get_llm_config()
     return prompts.get(name, "")
 
 
 def run_prompt(prompt_name: str, variables: dict | None = None, clean: bool = True) -> str:
-    api_key, model, prompts = _get_openai_config()
-    if not api_key or not model:
-        raise RuntimeError("OpenAI API key or model not configured")
+    oa_key, groq_key, model, prompts = _get_llm_config()
+    if model in GROQ_MODELS:
+        api_key = groq_key
+        if not api_key or Groq is None:
+            raise RuntimeError("Groq API key or model not configured")
+        client = Groq(api_key=api_key)
+    else:
+        api_key = oa_key
+        if not api_key:
+            raise RuntimeError("OpenAI API key or model not configured")
+        client = OpenAI(api_key=api_key)
     if prompt_name == "company_alias":
         template = COMPANY_ALIAS_PROMPT
     else:
@@ -78,7 +113,6 @@ def run_prompt(prompt_name: str, variables: dict | None = None, clean: bool = Tr
             "explanation or extra formatting."
         )
 
-    client = OpenAI(api_key=api_key)
     response = client.chat.completions.create(
         model=model,
         messages=[{"role": "user", "content": prompt}],
@@ -99,9 +133,17 @@ def lookup_utc_offset(
     date : str, optional
         Date in ``YYYY-MM-DD`` format. If omitted, today's UTC date is used.
     """
-    api_key, model, _ = _get_openai_config()
-    if not api_key or not model:
-        raise RuntimeError("OpenAI API key or model not configured")
+    oa_key, groq_key, model, _ = _get_llm_config()
+    if model in GROQ_MODELS:
+        api_key = groq_key
+        if not api_key or Groq is None:
+            raise RuntimeError("Groq API key or model not configured")
+        client = Groq(api_key=api_key)
+    else:
+        api_key = oa_key
+        if not api_key:
+            raise RuntimeError("OpenAI API key or model not configured")
+        client = OpenAI(api_key=api_key)
 
     date = date or datetime.utcnow().strftime("%Y-%m-%d")
 
@@ -112,7 +154,6 @@ def lookup_utc_offset(
         f"Country: {country}\nState: {state}\nCity: {city}\nDate: {date}\nUTC offset:"
     )
 
-    client = OpenAI(api_key=api_key)
     response = client.chat.completions.create(
         model=model,
         messages=[{"role": "user", "content": prompt}],

--- a/config/settings.py
+++ b/config/settings.py
@@ -8,6 +8,7 @@ CONFIG_FILE = Path.home() / ".ai_contact_manager_config.json"
 
 DEFAULT_SETTINGS = {
     "openai_api_key": "",
+    "groq_api_key": "",
     "llm_model": "gpt-4.1",
     "prompts": {
         "target_company_validation": "",

--- a/ui/settings_panel.py
+++ b/ui/settings_panel.py
@@ -32,7 +32,7 @@ class SettingsDialog(QDialog):
         layout = QVBoxLayout(self)
 
         form = QFormLayout()
-        # API Key
+        # API Keys
         self.api_key_edit = QLineEdit(self._settings.get("openai_api_key", ""))
         self.api_key_edit.setEchoMode(QLineEdit.Password)
         self.api_key_edit.setPlaceholderText("sk-...")
@@ -42,15 +42,30 @@ class SettingsDialog(QDialog):
         )
         form.addRow("OpenAI API Key", self.api_key_edit)
 
+        self.groq_key_edit = QLineEdit(self._settings.get("groq_api_key", ""))
+        self.groq_key_edit.setEchoMode(QLineEdit.Password)
+        self.groq_key_edit.setPlaceholderText("gsk-...")
+        self.groq_key_edit.setToolTip("Your Groq API key")
+        self.groq_key_edit.editingFinished.connect(
+            lambda: update_setting("groq_api_key", self.groq_key_edit.text())
+        )
+        form.addRow("Groq API Key", self.groq_key_edit)
+
         # Model selection
         self.model_combo = QComboBox()
-        self.model_combo.addItems([
-            "gpt-4.1",
-            "gpt-4.1-mini",
-            "gpt-4.1-nano",
-            "gpt-4o-mini",
-            "o3-mini",
-        ])
+        self.model_combo.addItems(
+            [
+                "gpt-4.1",
+                "gpt-4.1-mini",
+                "gpt-4.1-nano",
+                "gpt-4o-mini",
+                "o3-mini",
+                "gemma2-9b-it",
+                "llama-3.1-8b-instant",
+                "llama-3.3-70b-versatile",
+                "meta-llama/llama-guard-4-12b",
+            ]
+        )
         self.model_combo.setCurrentText(self._settings.get("llm_model", "gpt-4.1"))
         self.model_combo.currentIndexChanged[str].connect(
             lambda text: update_setting("llm_model", text)

--- a/update_call_times.py
+++ b/update_call_times.py
@@ -10,7 +10,7 @@ def update_call_times(force_lookup: bool = False) -> int:
     ----------
     force_lookup : bool, optional
         If True, lookup the UTC offset for contacts missing the ``time_zone_utc``
-        field using the OpenAI API. Otherwise only contacts with an existing
+        field using the OpenAI or Groq API. Otherwise only contacts with an existing
         ``time_zone_utc`` value will be processed.
 
     Returns
@@ -59,7 +59,7 @@ def main() -> None:
     parser.add_argument(
         "--force-lookup",
         action="store_true",
-        help="lookup missing UTC offsets using OpenAI",
+        help="lookup missing UTC offsets using the configured LLM",
     )
     args = parser.parse_args()
     updated = update_call_times(force_lookup=args.force_lookup)


### PR DESCRIPTION
## Summary
- add Groq API key setting and extra models
- support Groq in LLM manager
- update settings dialog to allow Groq key and models
- document how to use Groq
- generalize update_call_times help text

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `go vet ./...` *(fails: Forbidden)*
- `go build ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685daad29a5c8332bcc9c98389cc33db