### PR TITLE
Enable optional web search in AI Power Up

### DIFF
--- a/ai/llm_manager.py
+++ b/ai/llm_manager.py
@@ -59,7 +59,12 @@ def get_prompt(name: str) -> str:
     return prompts.get(name, "")
 
 
-def run_prompt(prompt_name: str, variables: dict | None = None, clean: bool = True) -> str:
+def run_prompt(
+    prompt_name: str,
+    variables: dict | None = None,
+    clean: bool = True,
+    web_search: bool = False,
+) -> str:
     oa_key, groq_key, model, prompts = _get_llm_config()
     if model in GROQ_MODELS:
         api_key = groq_key
@@ -113,11 +118,21 @@ def run_prompt(prompt_name: str, variables: dict | None = None, clean: bool = Tr
             "explanation or extra formatting."
         )
 
-    response = client.chat.completions.create(
-        model=model,
-        messages=[{"role": "user", "content": prompt}],
-    )
-    text = response.choices[0].message.content
+    if web_search:
+        if model not in OPENAI_MODELS:
+            raise RuntimeError("Web search is only supported for OpenAI models")
+        response = client.responses.create(
+            model=model,
+            tools=[{"type": "web_search_preview"}],
+            input=prompt,
+        )
+        text = response.output_text
+    else:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        text = response.choices[0].message.content
     return text.strip() if clean else text
 
 

--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -703,7 +703,7 @@ class ContactsTableWidget(QWidget):
                 else:
                     prompt = mapping.get(field)
                     if prompt:
-                        result = run_prompt(prompt, contact)
+                        result = run_prompt(prompt, contact, web_search=opts.get("web_search", False))
                         self.db.update_contact(contact["profile_id"], {field: result})
             except Exception as exc:  # noqa: BLE001
                 self._status_callback(str(exc))

--- a/ui/power_up_dialog.py
+++ b/ui/power_up_dialog.py
@@ -6,6 +6,7 @@ from PyQt5.QtWidgets import (
     QRadioButton,
     QSpinBox,
     QGroupBox,
+    QCheckBox,
 )
 
 
@@ -43,6 +44,9 @@ class PowerUpDialog(QDialog):
         override_layout.addWidget(self.empty_radio)
         layout.addWidget(override_box)
 
+        self.search_checkbox = QCheckBox("Búsqueda en Internet")
+        layout.addWidget(self.search_checkbox)
+
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
@@ -59,4 +63,5 @@ class PowerUpDialog(QDialog):
             "scope": scope,
             "limit": self.limit_spin.value(),
             "override": self.override_radio.isChecked(),
+            "web_search": self.search_checkbox.isChecked(),
         }


### PR DESCRIPTION
## Summary
- add `Búsqueda en Internet` checkbox in the Power Up dialog
- pass the selected value when running prompts
- support `web_search_preview` via `OpenAI.responses.create`

## Testing
- `python -m py_compile ai/llm_manager.py ui/power_up_dialog.py ui/contacts_table.py`

------
https://chatgpt.com/codex/tasks/task_e_685db18b55b08332a8d8e2142ada065d