### PR TITLE
Add prompt editing dialog

### DIFF
--- a/ai/llm_manager.py
+++ b/ai/llm_manager.py
@@ -53,9 +53,9 @@ def is_configured() -> bool:
 
 
 def get_prompt(name: str) -> str:
-    if name == "company_alias":
-        return COMPANY_ALIAS_PROMPT
     _oa, _groq, _model, prompts = _get_llm_config()
+    if name == "company_alias":
+        return prompts.get(name, COMPANY_ALIAS_PROMPT)
     return prompts.get(name, "")
 
 
@@ -77,7 +77,7 @@ def run_prompt(
             raise RuntimeError("OpenAI API key or model not configured")
         client = OpenAI(api_key=api_key)
     if prompt_name == "company_alias":
-        template = COMPANY_ALIAS_PROMPT
+        template = prompts.get(prompt_name, COMPANY_ALIAS_PROMPT)
     else:
         template = prompts.get(prompt_name)
         if not template:

--- a/ai/prompts.py
+++ b/ai/prompts.py
@@ -1,0 +1,11 @@
+"""Constants for mapping table fields to prompt keys."""
+
+FIELD_TO_PROMPT = {
+    "target_company": "target_company_validation",
+    "contact_icp_status": "icp_validation",
+    "clients_of_contact": "clients_of_contact",
+    "area_of_business": "area_of_business",
+    "most_relevant_summit": "most_relevant_summit",
+    "client_icp": "client_icp",
+    "company_alias": "company_alias",
+}

--- a/config/settings.py
+++ b/config/settings.py
@@ -17,6 +17,7 @@ DEFAULT_SETTINGS = {
         "area_of_business": "",
         "most_relevant_summit": "",
         "client_icp": "",
+        "company_alias": "",
     },
     "timezone": {
         "utc_offset": 0,

--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -39,6 +39,7 @@ from ui.export_dialog import ExportOptionsDialog
 from exporter import export_contacts
 from ui.power_up_dialog import PowerUpDialog
 from ai.llm_manager import run_prompt, lookup_utc_offset
+from ai.prompts import FIELD_TO_PROMPT
 from ai.enrichment import _calculate_call_times
 from utils import (
     disposition_to_status,
@@ -713,15 +714,7 @@ class ContactsTableWidget(QWidget):
         else:
             contacts = self.db.fetch_contacts()
 
-        mapping = {
-            "target_company": "target_company_validation",
-            "contact_icp_status": "icp_validation",
-            "clients_of_contact": "clients_of_contact",
-            "area_of_business": "area_of_business",
-            "most_relevant_summit": "most_relevant_summit",
-            "client_icp": "client_icp",
-            "company_alias": "company_alias",
-        }
+        mapping = FIELD_TO_PROMPT
 
         progress = QProgressDialog("Running AI Power Up...", None, 0, len(contacts), self)
         progress.setWindowModality(Qt.WindowModal)

--- a/ui/filter_popup.py
+++ b/ui/filter_popup.py
@@ -8,6 +8,8 @@ from PyQt5.QtWidgets import (
     QHBoxLayout,
     QGroupBox,
 )
+from ai.prompts import FIELD_TO_PROMPT
+from ui.prompt_edit_dialog import PromptEditDialog
 from PyQt5.QtCore import Qt, pyqtSignal
 
 
@@ -64,6 +66,9 @@ class FilterPopup(QWidget):
             self.power_btn = QPushButton("Run Prompt")
             self.power_btn.clicked.connect(lambda: self._ai_callback(self._field))
             power_layout.addWidget(self.power_btn)
+            self.edit_btn = QPushButton("Edit Prompt")
+            self.edit_btn.clicked.connect(self._edit_prompt)
+            power_layout.addWidget(self.edit_btn)
             layout.addWidget(power_box)
 
     def _populate(self):
@@ -99,6 +104,13 @@ class FilterPopup(QWidget):
         for i in range(self.list_widget.count()):
             self.list_widget.item(i).setCheckState(Qt.Unchecked)
         self.selection_changed.emit()
+
+    def _edit_prompt(self):
+        key = FIELD_TO_PROMPT.get(self._field)
+        if not key:
+            return
+        dialog = PromptEditDialog(key, self)
+        dialog.exec()
 
     def closeEvent(self, event):
         self.closed.emit()

--- a/ui/prompt_edit_dialog.py
+++ b/ui/prompt_edit_dialog.py
@@ -1,0 +1,26 @@
+from PyQt5.QtWidgets import QDialog, QVBoxLayout, QPlainTextEdit, QDialogButtonBox
+
+from config.settings import get_settings, update_setting
+
+
+class PromptEditDialog(QDialog):
+    """Dialog for editing an AI prompt template."""
+
+    def __init__(self, prompt_key: str, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Edit Prompt")
+        self._key = prompt_key
+        layout = QVBoxLayout(self)
+        prompts = get_settings().get("prompts", {})
+        self.edit = QPlainTextEdit(prompts.get(prompt_key, ""))
+        self.edit.setMinimumWidth(500)
+        self.edit.setMinimumHeight(300)
+        layout.addWidget(self.edit)
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def accept(self):
+        update_setting(f"prompts.{self._key}", self.edit.toPlainText())
+        super().accept()

--- a/ui/settings_panel.py
+++ b/ui/settings_panel.py
@@ -74,28 +74,7 @@ class SettingsDialog(QDialog):
 
         layout.addLayout(form)
 
-        # Prompts section
-        prompts_box = QGroupBox("Prompt Templates")
-        prompts_layout = QFormLayout(prompts_box)
-        psettings = self._settings.get("prompts", {})
-        self.prompt_edits = {}
-        prompts = [
-            ("target_company_validation", "Target Company Validation"),
-            ("icp_validation", "ICP Validation"),
-            ("clients_of_contact", "Clients of Contact"),
-            ("area_of_business", "Area of Business"),
-            ("most_relevant_summit", "Most Relevant Summit"),
-            ("client_icp", "ICP of the Client"),
-        ]
-        for key, label in prompts:
-            edit = QPlainTextEdit(psettings.get(key, ""))
-            edit.setToolTip(f"Prompt template for {label}")
-            edit.textChanged.connect(
-                lambda k=key, e=edit: update_setting(f"prompts.{k}", e.toPlainText())
-            )
-            prompts_layout.addRow(label, edit)
-            self.prompt_edits[key] = edit
-        layout.addWidget(prompts_box)
+
 
         # Time zone settings
         tz_box = QGroupBox("Time Zone")


### PR DESCRIPTION
## Summary
- allow customizing built-in prompts
- add `PromptEditDialog`
- expose mapping of fields to prompt keys
- integrate `Edit Prompt` in filter popup
- remove prompt templates from settings panel

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685dbb08c6dc8332abb6178cf2bbddc5