### PR TITLE
Enable dynamic prompt variables and full column control

### DIFF
--- a/ai/llm_manager.py
+++ b/ai/llm_manager.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import re
 from openai import OpenAI
 try:
     from groq import Groq
@@ -84,31 +85,11 @@ def run_prompt(
             raise RuntimeError(f"Prompt template '{prompt_name}' not configured")
     variables = variables or {}
 
-    # Format the user's template with the given variables
-    prompt = template.format(**variables)
+    # Replace {{var}} placeholders with the corresponding values
+    def _replace(match: re.Match) -> str:
+        return str(variables.get(match.group(1), ""))
 
-    # Build contextual lines with available variables
-    context_lines = []
-    key_map = {
-        "company_name": "Company Name",
-        "headcount": "Headcount",
-        "company_description": "Company Description",
-        "first_name": "First Name",
-        "last_name": "Last Name",
-        "job_title": "Job Title",
-    }
-    for key, label in key_map.items():
-        value = variables.get(key)
-        if value:
-            context_lines.append(f"{label}: {value}")
-
-    for key, value in variables.items():
-        if key not in key_map and value not in (None, ""):
-            pretty = key.replace("_", " ").title()
-            context_lines.append(f"{pretty}: {value}")
-
-    if context_lines:
-        prompt = f"{prompt}\n\n" + "\n".join(context_lines)
+    prompt = re.sub(r"\{\{\s*(\w+)\s*\}\}", _replace, template)
 
     if prompt_name in {"target_company_validation", "icp_validation"}:
         prompt += '\n\nAnswer ONLY "Yes" or "No". Do not add anything else.'

--- a/db_manager.py
+++ b/db_manager.py
@@ -533,3 +533,20 @@ class DBManager:
             return sorted(result)
 
         return sorted(str(v) for v in values if v is not None)
+
+    def get_columns(self) -> list[str]:
+        """Return a sorted list with all column names in the contacts table."""
+        self.create_contacts_table()
+        if self._columns_cache is None:
+            conn = self.connect()
+            cur = conn.cursor()
+            if self.use_postgres:
+                cur.execute(
+                    "SELECT column_name FROM information_schema.columns WHERE table_name='contacts'"
+                )
+                self._columns_cache = {r[0] for r in cur.fetchall()}
+            else:
+                self._columns_cache = {
+                    row[1] for row in cur.execute("PRAGMA table_info(contacts)")
+                }
+        return sorted(self._columns_cache)

--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -52,7 +52,7 @@ from utils import (
 class ContactsTableWidget(QWidget):
     """Widget displaying contacts with filtering and batch actions."""
 
-    HEADERS = [
+    BASE_HEADERS = [
         "mobile",
         "first_name",
         "last_name",
@@ -87,17 +87,21 @@ class ContactsTableWidget(QWidget):
         "most_relevant_summit",
         "client_icp",
         "company_alias",
-        "time_zone_utc",
     ]
 
     def __init__(self, db: DBManager, status_callback=None, parent=None):
         super().__init__(parent)
         self.db = db
         self._status_callback = status_callback or (lambda *args, **kwargs: None)
+        all_cols = self.db.get_columns()
+        self.HEADERS = self.BASE_HEADERS[:]
+        for col in all_cols:
+            if col not in self.HEADERS:
+                self.HEADERS.append(col)
+        self.column_visibility = {h: (h in self.BASE_HEADERS) for h in self.HEADERS}
         self.contacts = []
         self.filtered_contacts = []
         self.search_text = ""
-        self.column_visibility = {h: True for h in self.HEADERS}
         self.filters = {}
         self.sort_column = None
         self.sort_order = Qt.AscendingOrder

--- a/ui/filter_popup.py
+++ b/ui/filter_popup.py
@@ -66,9 +66,10 @@ class FilterPopup(QWidget):
             self.power_btn = QPushButton("Run Prompt")
             self.power_btn.clicked.connect(lambda: self._ai_callback(self._field))
             power_layout.addWidget(self.power_btn)
-            self.edit_btn = QPushButton("Edit Prompt")
-            self.edit_btn.clicked.connect(self._edit_prompt)
-            power_layout.addWidget(self.edit_btn)
+            if self._field in FIELD_TO_PROMPT:
+                self.edit_btn = QPushButton("Edit Prompt")
+                self.edit_btn.clicked.connect(self._edit_prompt)
+                power_layout.addWidget(self.edit_btn)
             layout.addWidget(power_box)
 
     def _populate(self):

--- a/ui/prompt_edit_dialog.py
+++ b/ui/prompt_edit_dialog.py
@@ -1,4 +1,13 @@
-from PyQt5.QtWidgets import QDialog, QVBoxLayout, QPlainTextEdit, QDialogButtonBox
+from PyQt5.QtWidgets import (
+    QDialog,
+    QVBoxLayout,
+    QPlainTextEdit,
+    QDialogButtonBox,
+    QLabel,
+    QHBoxLayout,
+    QWidget,
+)
+import re
 
 from config.settings import get_settings, update_setting
 
@@ -16,6 +25,12 @@ class PromptEditDialog(QDialog):
         self.edit.setMinimumWidth(500)
         self.edit.setMinimumHeight(300)
         layout.addWidget(self.edit)
+        self.vars_container = QWidget()
+        self.vars_layout = QHBoxLayout(self.vars_container)
+        self.vars_layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(self.vars_container)
+        self.edit.textChanged.connect(self._update_vars)
+        self._update_vars()
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
@@ -24,3 +39,19 @@ class PromptEditDialog(QDialog):
     def accept(self):
         update_setting(f"prompts.{self._key}", self.edit.toPlainText())
         super().accept()
+
+    def _update_vars(self):
+        """Parse the prompt and display detected dynamic variables."""
+        text = self.edit.toPlainText()
+        vars_found = sorted(set(re.findall(r"\{\{\s*(\w+)\s*\}\}", text)))
+        while self.vars_layout.count():
+            item = self.vars_layout.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+        for var in vars_found:
+            label = QLabel(var)
+            label.setStyleSheet(
+                "QLabel { border: 1px solid #888; border-radius: 4px; padding: 2px 4px; }"
+            )
+            self.vars_layout.addWidget(label)
+        self.vars_container.setVisible(bool(vars_found))


### PR DESCRIPTION
## Summary
- allow fetching of all table columns and expose via `get_columns`
- support `{{variable}}` placeholders in prompts with simple substitution
- let table include any database column and hide timezone star
- only show `Edit Prompt` when a prompt exists
- highlight detected variables when editing prompts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685dc0217204833295b4d2c8b73c82f7