### PR TITLE
Improve column/customize UI

### DIFF
--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -9,7 +9,7 @@ from PyQt5.QtWidgets import (
     QCheckBox,
     QDialog,
     QDialogButtonBox,
-    QFormLayout,
+    QGridLayout,
     QLabel,
     QPushButton,
     QSpinBox,
@@ -188,6 +188,12 @@ class ContactsTableWidget(QWidget):
         header.customContextMenuRequested.connect(self._show_filter_context)
         self._filter_header = header
         self.table.cellClicked.connect(self._on_cell_clicked)
+        self.table.horizontalHeader().sectionClicked.connect(
+            self._on_header_section_clicked
+        )
+        self.table.verticalHeader().sectionClicked.connect(
+            self._on_row_section_clicked
+        )
         layout.addWidget(self.table)
 
         nav = QHBoxLayout()
@@ -457,15 +463,18 @@ class ContactsTableWidget(QWidget):
     def _customize_columns(self):
         dialog = QDialog(self)
         dialog.setWindowTitle("Customize Columns")
-        form = QFormLayout(dialog)
+        grid = QGridLayout(dialog)
         checkboxes = {}
-        for header in self.HEADERS:
+        cols = 4
+        for idx, header in enumerate(self.HEADERS):
             cb = QCheckBox(header)
             cb.setChecked(self.column_visibility[header])
-            form.addRow(cb)
+            row = idx // cols
+            col = idx % cols
+            grid.addWidget(cb, row, col)
             checkboxes[header] = cb
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
-        form.addRow(buttons)
+        grid.addWidget(buttons, (len(self.HEADERS) + cols - 1) // cols + 1, 0, 1, cols)
         buttons.accepted.connect(dialog.accept)
         buttons.rejected.connect(dialog.reject)
         if dialog.exec() == QDialog.Accepted:
@@ -553,6 +562,10 @@ class ContactsTableWidget(QWidget):
 
     def _on_cell_clicked(self, row, column):
         if self.quick_mode not in {"add", "remove"}:
+            sel = self.table.selectionModel()
+            idx = self.table.model().index(row, column)
+            if sel.isSelected(idx) and len(sel.selectedIndexes()) == 1:
+                self.table.clearSelection()
             return
         if self.quick_mode == "add":
             if self.HEADERS[column] != "tags":
@@ -572,6 +585,18 @@ class ContactsTableWidget(QWidget):
         self._apply_filters()
         self.table.verticalScrollBar().setValue(scroll)
         self._status_callback("Tag removed")
+
+    def _on_header_section_clicked(self, index):
+        sel = self.table.selectionModel()
+        selected = [i.column() for i in sel.selectedColumns()]
+        if len(selected) == 1 and selected[0] == index:
+            self.table.clearSelection()
+
+    def _on_row_section_clicked(self, index):
+        sel = self.table.selectionModel()
+        selected = [i.row() for i in sel.selectedRows()]
+        if len(selected) == 1 and selected[0] == index:
+            self.table.clearSelection()
 
     def _change_page(self, delta: int):
         new_page = self.page + delta

--- a/ui/filter_popup.py
+++ b/ui/filter_popup.py
@@ -111,7 +111,9 @@ class FilterPopup(QWidget):
         if not key:
             return
         dialog = PromptEditDialog(key, self)
-        dialog.exec()
+        dialog.setWindowModality(Qt.NonModal)
+        dialog.setAttribute(Qt.WA_DeleteOnClose)
+        dialog.show()
 
     def closeEvent(self, event):
         self.closed.emit()

--- a/ui/flow_layout.py
+++ b/ui/flow_layout.py
@@ -1,0 +1,75 @@
+from PyQt5.QtWidgets import QLayout
+from PyQt5.QtCore import QSize, Qt, QRect, QPoint
+
+
+class FlowLayout(QLayout):
+    """Layout that arranges child widgets horizontally and wraps them."""
+
+    def __init__(self, parent=None, margin=0, spacing=-1):
+        super().__init__(parent)
+        self._items = []
+        self.setContentsMargins(margin, margin, margin, margin)
+        self.setSpacing(spacing)
+
+    def addItem(self, item):
+        self._items.append(item)
+
+    def count(self):
+        return len(self._items)
+
+    def itemAt(self, index):
+        if 0 <= index < len(self._items):
+            return self._items[index]
+        return None
+
+    def takeAt(self, index):
+        if 0 <= index < len(self._items):
+            return self._items.pop(index)
+        return None
+
+    def expandingDirections(self):
+        return Qt.Orientations(Qt.Orientation(0))
+
+    def hasHeightForWidth(self):
+        return True
+
+    def heightForWidth(self, width):
+        return self._do_layout(QRect(0, 0, width, 0), True)
+
+    def setGeometry(self, rect):
+        super().setGeometry(rect)
+        self._do_layout(rect, False)
+
+    def sizeHint(self):
+        return self.minimumSize()
+
+    def minimumSize(self):
+        size = QSize()
+        for item in self._items:
+            size = size.expandedTo(item.minimumSize())
+        m = self.contentsMargins()
+        size += QSize(m.left() + m.right(), m.top() + m.bottom())
+        return size
+
+    def _do_layout(self, rect, test_only):
+        x = rect.x()
+        y = rect.y()
+        line_height = 0
+        for item in self._items:
+            wid = item.widget()
+            if wid is None:
+                continue
+            hint = item.sizeHint()
+            space_x = self.spacing()
+            space_y = self.spacing()
+            next_x = x + hint.width() + space_x
+            if next_x - space_x > rect.right() and line_height > 0:
+                x = rect.x()
+                y = y + line_height + space_y
+                next_x = x + hint.width() + space_x
+                line_height = 0
+            if not test_only:
+                item.setGeometry(QRect(QPoint(x, y), hint))
+            x = next_x
+            line_height = max(line_height, hint.height())
+        return y + line_height - rect.y()

--- a/ui/prompt_edit_dialog.py
+++ b/ui/prompt_edit_dialog.py
@@ -4,12 +4,13 @@ from PyQt5.QtWidgets import (
     QPlainTextEdit,
     QDialogButtonBox,
     QLabel,
-    QHBoxLayout,
     QWidget,
+    QSizePolicy,
 )
 import re
 
 from config.settings import get_settings, update_setting
+from ui.flow_layout import FlowLayout
 
 
 class PromptEditDialog(QDialog):
@@ -26,7 +27,7 @@ class PromptEditDialog(QDialog):
         self.edit.setMinimumHeight(300)
         layout.addWidget(self.edit)
         self.vars_container = QWidget()
-        self.vars_layout = QHBoxLayout(self.vars_container)
+        self.vars_layout = FlowLayout(self.vars_container, spacing=4)
         self.vars_layout.setContentsMargins(0, 0, 0, 0)
         layout.addWidget(self.vars_container)
         self.edit.textChanged.connect(self._update_vars)
@@ -53,5 +54,6 @@ class PromptEditDialog(QDialog):
             label.setStyleSheet(
                 "QLabel { border: 1px solid #888; border-radius: 4px; padding: 2px 4px; }"
             )
+            label.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
             self.vars_layout.addWidget(label)
         self.vars_container.setVisible(bool(vars_found))


### PR DESCRIPTION
## Summary
- add FlowLayout to show prompt variables in a wrapped row layout
- shrink variable labels and wrap them
- allow editing prompts without blocking the table
- show Customize Columns checkboxes in a 4-column grid
- allow deselecting rows/columns by clicking again

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dc3dd81bc833294b8c8ede4c0e8a8