### PR TITLE
Add Perplexity integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,40 @@ Available Groq models you can select are:
 - `llama-3.3-70b-versatile`
 - `meta-llama/llama-guard-4-12b`
 
+## Using Perplexity
+
+The application also supports Perplexity's API. Enter your Perplexity API key
+and choose one of the available models in the **Settings** dialog.
+
+```python
+import requests
+
+headers = {
+    "authorization": "Bearer YOUR_API_KEY",
+    "content-type": "application/json",
+}
+
+payload = {
+    "model": "sonar-pro",
+    "messages": [{"role": "user", "content": "Hello"}],
+    "stream": False,
+    "search_mode": "web",
+    "web_search_options": {"search_context_size": "low"},
+}
+
+response = requests.post(
+    "https://api.perplexity.ai/chat/completions",
+    headers=headers,
+    json=payload,
+)
+print(response.json()["choices"][0]["message"]["content"])
+```
+
+Available Perplexity models you can select are:
+
+- `sonar`
+- `sonar-pro`
+
 Use only the base model name (e.g. `"gpt-4.1"`) without any date suffixes.
 
 The company alias field is always generated automatically during enrichment.

--- a/ai/llm_manager.py
+++ b/ai/llm_manager.py
@@ -36,6 +36,11 @@ GROQ_MODELS = {
     "meta-llama/llama-guard-4-12b",
 }
 
+PERPLEXITY_MODELS = {
+    "sonar",
+    "sonar-pro",
+}
+
 
 _EXECUTOR = ThreadPoolExecutor(max_workers=4)
 
@@ -45,20 +50,23 @@ def _get_llm_config():
     return (
         settings.get("openai_api_key"),
         settings.get("groq_api_key"),
+        settings.get("perplexity_api_key"),
         settings.get("llm_model"),
         settings.get("prompts", {}),
     )
 
 
 def is_configured() -> bool:
-    oa_key, groq_key, model, _ = _get_llm_config()
+    oa_key, groq_key, pplx_key, model, _ = _get_llm_config()
     if model in GROQ_MODELS:
         return bool(groq_key and model)
+    if model in PERPLEXITY_MODELS:
+        return bool(pplx_key and model)
     return bool(oa_key and model)
 
 
 def get_prompt(name: str) -> str:
-    _oa, _groq, _model, prompts = _get_llm_config()
+    _oa, _groq, _pplx, _model, prompts = _get_llm_config()
     if name == "company_alias":
         return prompts.get(name, COMPANY_ALIAS_PROMPT)
     return prompts.get(name, "")
@@ -70,13 +78,19 @@ def run_prompt(
     clean: bool = True,
     web_search: bool = False,
 ) -> str:
-    oa_key, groq_key, model, prompts = _get_llm_config()
+    oa_key, groq_key, pplx_key, model, prompts = _get_llm_config()
     if model in GROQ_MODELS:
         api_key = groq_key
         if not api_key or Groq is None:
             raise RuntimeError("Groq API key or model not configured")
         client = Groq(api_key=api_key)
         print(f"[Groq] model={model} prompt={prompt_name}")
+    elif model in PERPLEXITY_MODELS:
+        api_key = pplx_key
+        if not api_key:
+            raise RuntimeError("Perplexity API key or model not configured")
+        client = None
+        print(f"[Perplexity] model={model} prompt={prompt_name}")
     else:
         api_key = oa_key
         if not api_key:
@@ -105,23 +119,52 @@ def run_prompt(
             "explanation or extra formatting."
         )
 
-    if web_search:
-        if model not in OPENAI_MODELS:
-            raise RuntimeError("Web search is only supported for OpenAI models")
-        print("[LLM] performing web search request")
-        response = client.responses.create(
-            model=model,
-            tools=[{"type": "web_search_preview"}],
-            input=prompt,
+    if model in PERPLEXITY_MODELS:
+        import requests  # local import to avoid mandatory dependency
+
+        print("[LLM] sending Perplexity request")
+        headers = {
+            "accept": "application/json",
+            "authorization": f"Bearer {api_key}",
+            "content-type": "application/json",
+        }
+        payload = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+        }
+        if web_search:
+            payload["search_mode"] = "web"
+            payload["web_search_options"] = {"search_context_size": "low"}
+        response = requests.post(
+            "https://api.perplexity.ai/chat/completions",
+            headers=headers,
+            json=payload,
+            timeout=30,
         )
-        text = response.output_text
+        response.raise_for_status()
+        data = response.json()
+        text = data["choices"][0]["message"]["content"]
     else:
-        print("[LLM] sending chat completion request")
-        response = client.chat.completions.create(
-            model=model,
-            messages=[{"role": "user", "content": prompt}],
-        )
-        text = response.choices[0].message.content
+        if web_search:
+            if model not in OPENAI_MODELS:
+                raise RuntimeError(
+                    "Web search is only supported for OpenAI models"
+                )
+            print("[LLM] performing web search request")
+            response = client.responses.create(
+                model=model,
+                tools=[{"type": "web_search_preview"}],
+                input=prompt,
+            )
+            text = response.output_text
+        else:
+            print("[LLM] sending chat completion request")
+            response = client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            text = response.choices[0].message.content
     print("[LLM] response received")
     return text.strip() if clean else text
 
@@ -148,13 +191,19 @@ def lookup_utc_offset(
     date : str, optional
         Date in ``YYYY-MM-DD`` format. If omitted, today's UTC date is used.
     """
-    oa_key, groq_key, model, _ = _get_llm_config()
+    oa_key, groq_key, pplx_key, model, _ = _get_llm_config()
     if model in GROQ_MODELS:
         api_key = groq_key
         if not api_key or Groq is None:
             raise RuntimeError("Groq API key or model not configured")
         client = Groq(api_key=api_key)
         print(f"[Groq] lookup timezone model={model}")
+    elif model in PERPLEXITY_MODELS:
+        api_key = pplx_key
+        if not api_key:
+            raise RuntimeError("Perplexity API key or model not configured")
+        client = None
+        print(f"[Perplexity] lookup timezone model={model}")
     else:
         api_key = oa_key
         if not api_key:
@@ -171,12 +220,36 @@ def lookup_utc_offset(
         f"Country: {country}\nState: {state}\nCity: {city}\nDate: {date}\nUTC offset:"
     )
     print("[LLM] sending time zone request")
-    response = client.chat.completions.create(
-        model=model,
-        messages=[{"role": "user", "content": prompt}],
-    )
+    if model in PERPLEXITY_MODELS:
+        import requests
+
+        headers = {
+            "accept": "application/json",
+            "authorization": f"Bearer {api_key}",
+            "content-type": "application/json",
+        }
+        payload = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": False,
+        }
+        response = requests.post(
+            "https://api.perplexity.ai/chat/completions",
+            headers=headers,
+            json=payload,
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()
+        text = data["choices"][0]["message"]["content"]
+    else:
+        response = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        text = response.choices[0].message.content
     print("[LLM] time zone response received")
-    return response.choices[0].message.content.strip()
+    return text.strip()
 
 
 def lookup_utc_offset_async(

--- a/config/settings.py
+++ b/config/settings.py
@@ -9,6 +9,7 @@ CONFIG_FILE = Path.home() / ".ai_contact_manager_config.json"
 DEFAULT_SETTINGS = {
     "openai_api_key": "",
     "groq_api_key": "",
+    "perplexity_api_key": "",
     "llm_model": "gpt-4.1",
     "prompts": {
         "target_company_validation": "",

--- a/ui/settings_panel.py
+++ b/ui/settings_panel.py
@@ -51,6 +51,15 @@ class SettingsDialog(QDialog):
         )
         form.addRow("Groq API Key", self.groq_key_edit)
 
+        self.pplx_key_edit = QLineEdit(self._settings.get("perplexity_api_key", ""))
+        self.pplx_key_edit.setEchoMode(QLineEdit.Password)
+        self.pplx_key_edit.setPlaceholderText("pk-...")
+        self.pplx_key_edit.setToolTip("Your Perplexity API key")
+        self.pplx_key_edit.editingFinished.connect(
+            lambda: update_setting("perplexity_api_key", self.pplx_key_edit.text())
+        )
+        form.addRow("Perplexity API Key", self.pplx_key_edit)
+
         # Model selection
         self.model_combo = QComboBox()
         self.model_combo.addItems(
@@ -64,6 +73,8 @@ class SettingsDialog(QDialog):
                 "llama-3.1-8b-instant",
                 "llama-3.3-70b-versatile",
                 "meta-llama/llama-guard-4-12b",
+                "sonar",
+                "sonar-pro",
             ]
         )
         self.model_combo.setCurrentText(self._settings.get("llm_model", "gpt-4.1"))


### PR DESCRIPTION
## Summary
- support Perplexity API in `llm_manager`
- store Perplexity API key in settings
- expose Perplexity key and models in Settings dialog
- document how to call Perplexity in README
- fix Perplexity model name

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685eb5772f748332a988f087207edfd4