### PR TITLE
Fix empty tag filter quoting

### DIFF
--- a/db_manager.py
+++ b/db_manager.py
@@ -355,7 +355,10 @@ class DBManager:
                         tag_clauses = []
                         for tag in values:
                             if not tag:
-                                tag_clauses.append('(\"tags\" = "" OR \"tags\" IS NULL)')
+                                # Use single quotes for an empty string to avoid
+                                # generating an invalid identifier in SQL. This
+                                # works for both SQLite and PostgreSQL.
+                                tag_clauses.append("(\"tags\" = '' OR \"tags\" IS NULL)")
                                 continue
                             tag_clauses.append(
                                 f'(\"tags\" = {ph} OR \"tags\" LIKE {ph} OR \"tags\" LIKE {ph} OR \"tags\" LIKE {ph})'


### PR DESCRIPTION
## Summary
- address SQL error when filtering empty tags

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eb90c019c83328e1d4accd3230e44