### PR TITLE
Implement DoubleCheck majority logic

### DIFF
--- a/ai/llm_manager.py
+++ b/ai/llm_manager.py
@@ -72,7 +72,17 @@ def get_prompt(name: str) -> str:
     return prompts.get(name, "")
 
 
-def run_prompt(
+def _sanitize_yes_no(text: str) -> str:
+    t = text.strip().rstrip(".").strip()
+    lower = t.lower()
+    if lower.startswith("yes"):
+        return "Yes"
+    if lower.startswith("no"):
+        return "No"
+    return t
+
+
+def _run_prompt_once(
     prompt_name: str,
     variables: dict | None = None,
     clean: bool = True,
@@ -166,7 +176,31 @@ def run_prompt(
             )
             text = response.choices[0].message.content
     print("[LLM] response received")
-    return text.strip() if clean else text
+    result = text.strip() if clean else text
+    if prompt_name in {"target_company_validation", "icp_validation"}:
+        result = _sanitize_yes_no(result)
+    return result
+
+
+def run_prompt(
+    prompt_name: str,
+    variables: dict | None = None,
+    clean: bool = True,
+    web_search: bool = False,
+    double_check: bool = False,
+) -> str:
+    if (
+        double_check
+        and prompt_name in {"target_company_validation", "icp_validation"}
+    ):
+        first = _run_prompt_once(prompt_name, variables, clean, web_search)
+        second = _run_prompt_once(prompt_name, variables, clean, web_search)
+        if first == second:
+            return first
+        third = _run_prompt_once(prompt_name, variables, clean, web_search)
+        yes_count = [first, second, third].count("Yes")
+        return "Yes" if yes_count >= 2 else "No"
+    return _run_prompt_once(prompt_name, variables, clean, web_search)
 
 
 def run_prompt_async(
@@ -174,9 +208,12 @@ def run_prompt_async(
     variables: dict | None = None,
     clean: bool = True,
     web_search: bool = False,
+    double_check: bool = False,
 ) -> Future:
     """Run ``run_prompt`` in a background thread and return a ``Future``."""
-    return _EXECUTOR.submit(run_prompt, prompt_name, variables, clean, web_search)
+    return _EXECUTOR.submit(
+        run_prompt, prompt_name, variables, clean, web_search, double_check
+    )
 
 
 def lookup_utc_offset(

--- a/tests/test_double_check.py
+++ b/tests/test_double_check.py
@@ -1,0 +1,45 @@
+import sys
+import types
+
+sys.modules.setdefault("openai", types.SimpleNamespace(OpenAI=lambda *a, **k: None))
+sys.modules.setdefault("groq", types.SimpleNamespace(Groq=lambda *a, **k: None))
+
+import ai.llm_manager as lm
+
+
+def _make_mock(responses):
+    calls = {"count": 0}
+
+    def fake_once(*args, **kwargs):
+        calls["count"] += 1
+        return lm._sanitize_yes_no(responses.pop(0))
+
+    return fake_once, calls
+
+
+def test_sanitize_yes_no(monkeypatch):
+    fake, calls = _make_mock(["Yes.  "])
+    monkeypatch.setattr(lm, "_run_prompt_once", fake)
+    assert lm.run_prompt("target_company_validation") == "Yes"
+    assert calls["count"] == 1
+
+
+def test_double_check_majority(monkeypatch):
+    fake, calls = _make_mock(["Yes.", "No", "No"])
+    monkeypatch.setattr(lm, "_run_prompt_once", fake)
+    assert lm.run_prompt("target_company_validation", double_check=True) == "No"
+    assert calls["count"] == 3
+
+
+def test_double_check_early_exit(monkeypatch):
+    fake, calls = _make_mock(["No", "No"])
+    monkeypatch.setattr(lm, "_run_prompt_once", fake)
+    assert lm.run_prompt("target_company_validation", double_check=True) == "No"
+    assert calls["count"] == 2
+
+
+def test_double_check_not_applied(monkeypatch):
+    fake, calls = _make_mock(["Foo"])
+    monkeypatch.setattr(lm, "_run_prompt_once", fake)
+    lm.run_prompt("clients_of_contact", double_check=True)
+    assert calls["count"] == 1

--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -893,6 +893,10 @@ class ContactsTableWidget(QWidget):
                             prompt,
                             contact,
                             web_search=opts.get("web_search", False),
+                            double_check=(
+                                opts.get("double_check", False)
+                                and field in {"target_company", "contact_icp_status"}
+                            ),
                         )
                         while not future.done():
                             QApplication.processEvents()

--- a/ui/power_up_dialog.py
+++ b/ui/power_up_dialog.py
@@ -47,6 +47,9 @@ class PowerUpDialog(QDialog):
         self.search_checkbox = QCheckBox("Internet Search")
         layout.addWidget(self.search_checkbox)
 
+        self.double_checkbox = QCheckBox("Double Check")
+        layout.addWidget(self.double_checkbox)
+
         buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         buttons.accepted.connect(self.accept)
         buttons.rejected.connect(self.reject)
@@ -64,4 +67,5 @@ class PowerUpDialog(QDialog):
             "limit": self.limit_spin.value(),
             "override": self.override_radio.isChecked(),
             "web_search": self.search_checkbox.isChecked(),
+            "double_check": self.double_checkbox.isChecked(),
         }


### PR DESCRIPTION
## Summary
- sanitize yes/no answers via `_sanitize_yes_no`
- add DoubleCheck majority logic to `run_prompt`
- allow async prompts to pass DoubleCheck flag
- expose DoubleCheck checkbox in Power Up dialog
- route option through contacts table
- test DoubleCheck behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ec19cd55483329235c2226e2e52f5