### PR TITLE
Implement Perplexity API throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ Available Perplexity models you can select are:
 
 Use only the base model name (e.g. `"gpt-4.1"`) without any date suffixes.
 
+Perplexity has very strict undocumented rate limits. To avoid failed
+requests when enriching large batches, the application throttles all
+Perplexity API calls to roughly two requests per second and no more than
+two concurrent connections. Each call is retried with exponential
+backoff if the API responds with an error.
+
 The company alias field is always generated automatically during enrichment.
 The application uses a fixed prompt that cannot be customized to produce a
 short, conversational version of the company name when the alias field is empty.

--- a/ai/llm_manager.py
+++ b/ai/llm_manager.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 import re
+import time
+from threading import Lock, Semaphore
 from concurrent.futures import ThreadPoolExecutor, Future
 from openai import OpenAI
 try:
@@ -43,6 +45,44 @@ PERPLEXITY_MODELS = {
 
 
 _EXECUTOR = ThreadPoolExecutor(max_workers=4)
+
+# Perplexity rate limiting constants
+_PPLX_MAX_QPS = 2
+_PPLX_MAX_CONCURRENCY = 2
+_PPLX_MAX_RETRIES = 3
+_PPLX_MIN_INTERVAL = 1.0 / _PPLX_MAX_QPS
+_pplx_last_time = 0.0
+_pplx_lock = Lock()
+_pplx_sema = Semaphore(_PPLX_MAX_CONCURRENCY)
+
+
+def _perplexity_request(headers: dict, payload: dict) -> str:
+    """Send a request to the Perplexity API with rate limiting and retries."""
+    import requests
+
+    url = "https://api.perplexity.ai/chat/completions"
+
+    def _do_request():
+        return requests.post(url, headers=headers, json=payload, timeout=30)
+
+    with _pplx_sema:
+        with _pplx_lock:
+            global _pplx_last_time
+            now = time.time()
+            wait = _PPLX_MIN_INTERVAL - (now - _pplx_last_time)
+            if wait > 0:
+                time.sleep(wait)
+            _pplx_last_time = time.time()
+        for attempt in range(_PPLX_MAX_RETRIES):
+            try:
+                resp = _do_request()
+                resp.raise_for_status()
+                data = resp.json()
+                return data["choices"][0]["message"]["content"]
+            except Exception:
+                if attempt == _PPLX_MAX_RETRIES - 1:
+                    raise
+                time.sleep(2 ** attempt)
 
 
 def _get_llm_config():
@@ -130,8 +170,6 @@ def _run_prompt_once(
         )
 
     if model in PERPLEXITY_MODELS:
-        import requests  # local import to avoid mandatory dependency
-
         print("[LLM] sending Perplexity request")
         headers = {
             "accept": "application/json",
@@ -146,15 +184,7 @@ def _run_prompt_once(
         if web_search:
             payload["search_mode"] = "web"
             payload["web_search_options"] = {"search_context_size": "low"}
-        response = requests.post(
-            "https://api.perplexity.ai/chat/completions",
-            headers=headers,
-            json=payload,
-            timeout=30,
-        )
-        response.raise_for_status()
-        data = response.json()
-        text = data["choices"][0]["message"]["content"]
+        text = _perplexity_request(headers, payload)
     else:
         if web_search:
             if model not in OPENAI_MODELS:
@@ -258,8 +288,6 @@ def lookup_utc_offset(
     )
     print("[LLM] sending time zone request")
     if model in PERPLEXITY_MODELS:
-        import requests
-
         headers = {
             "accept": "application/json",
             "authorization": f"Bearer {api_key}",
@@ -270,15 +298,7 @@ def lookup_utc_offset(
             "messages": [{"role": "user", "content": prompt}],
             "stream": False,
         }
-        response = requests.post(
-            "https://api.perplexity.ai/chat/completions",
-            headers=headers,
-            json=payload,
-            timeout=30,
-        )
-        response.raise_for_status()
-        data = response.json()
-        text = data["choices"][0]["message"]["content"]
+        text = _perplexity_request(headers, payload)
     else:
         response = client.chat.completions.create(
             model=model,


### PR DESCRIPTION
## Summary
- add Perplexity API rate limiting helper in `llm_manager`
- use the helper for all Perplexity requests with retries
- document the new throttling behaviour in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68614055cd4c83329cfd7effc225e8e4