### PR TITLE
Enable full contact exports

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -10,7 +10,16 @@ def _snake_case(text: str) -> str:
     return re.sub(r"[\s/-]+", "_", cleaned)
 
 
-def _chunk_list(items: List[dict], groups: int) -> List[List[dict]]:
+def _chunk_list(items: List[dict], groups: int, chunk_size: Optional[int] = None) -> List[List[dict]]:
+    """Split *items* into *groups* or by *chunk_size*."""
+    if chunk_size:
+        if chunk_size <= 0:
+            groups = 1
+        chunks = []
+        for i in range(0, len(items), chunk_size if chunk_size > 0 else len(items)):
+            chunks.append(items[i : i + chunk_size])
+        return chunks
+
     groups = max(1, groups)
     k, m = divmod(len(items), groups)
     chunks = []
@@ -39,6 +48,7 @@ def export_contacts(
     export_dir: str,
     groups: int = 1,
     split_by_tz: bool = False,
+    chunk_size: Optional[int] = None,
 ) -> int:
     """Export contacts to CSV files.
 
@@ -51,9 +61,12 @@ def export_contacts(
     export_dir : str
         Target directory where CSV files will be written.
     groups : int, optional
-        How many groups/chunks each time zone should be split into.
+        How many groups/chunks each time zone should be split into when
+        ``chunk_size`` is not specified.
     split_by_tz : bool, optional
         Whether to create separate files for each time zone.
+    chunk_size : int, optional
+        Maximum number of contacts per file. Overrides ``groups`` when set.
 
     Returns
     -------
@@ -85,7 +98,7 @@ def export_contacts(
             morning, afternoon = _calculate_call_times(tz)
             tz_suffix = f"{morning.replace(':', '_')}-{afternoon.replace(':', '_')}"
 
-        chunks = _chunk_list(clist, groups)
+        chunks = _chunk_list(clist, groups, chunk_size)
         for idx, chunk in enumerate(chunks):
             if not chunk:
                 continue

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,20 @@
+import sys
+import types
+
+sys.modules.setdefault("requests", types.SimpleNamespace(Session=lambda: None))
+
+import exporter
+
+
+def test_chunk_list_by_size():
+    items = [{'id': i} for i in range(25)]
+    chunks = exporter._chunk_list(items, groups=1, chunk_size=10)
+    assert len(chunks) == 3
+    assert [len(c) for c in chunks] == [10, 10, 5]
+
+
+def test_chunk_list_groups_fallback():
+    items = [{'id': i} for i in range(5)]
+    chunks = exporter._chunk_list(items, groups=2)
+    assert len(chunks) == 2
+    assert sum(len(c) for c in chunks) == 5

--- a/ui/contacts_table.py
+++ b/ui/contacts_table.py
@@ -844,7 +844,14 @@ class ContactsTableWidget(QWidget):
         dialog = ExportOptionsDialog(available, selected, self)
         if dialog.exec() != QDialog.Accepted:
             return
-        folder, split_by_tz, groups, fields = dialog.options()
+        (
+            folder,
+            split_by_tz,
+            groups,
+            chunk_size,
+            fields,
+            export_all,
+        ) = dialog.options()
         if not folder:
             QMessageBox.warning(self, "Export", "Folder name is required")
             return
@@ -854,12 +861,23 @@ class ContactsTableWidget(QWidget):
             return
         export_path = os.path.join(target_dir, folder)
         headers = [h for h in fields if self.column_visibility.get(h, True) and h != "Script"]
+        if export_all:
+            contacts = self.db.fetch_contacts(
+                filters={k: list(v) for k, v in self.filters.items()},
+                search=self.search_text,
+                sort_by=self.HEADERS[self.sort_column] if self.sort_column is not None else "",
+                sort_order="desc" if self.sort_order == Qt.DescendingOrder else "asc",
+            )
+        else:
+            contacts = self.filtered_contacts
+
         files = export_contacts(
-            self.filtered_contacts,
+            contacts,
             headers,
             export_path,
             groups,
             split_by_tz,
+            chunk_size,
         )
         QMessageBox.information(
             self,

--- a/ui/export_dialog.py
+++ b/ui/export_dialog.py
@@ -37,10 +37,18 @@ class ExportOptionsDialog(QDialog):
         self.tz_split = QCheckBox("Split by time zone")
         form.addRow(self.tz_split)
 
+        self.export_all = QCheckBox("Export all filtered contacts")
+        form.addRow(self.export_all)
+
         self.group_spin = QSpinBox()
         self.group_spin.setRange(1, 99)
         self.group_spin.setValue(1)
         form.addRow("Number of groups", self.group_spin)
+
+        self.chunk_spin = QSpinBox()
+        self.chunk_spin.setRange(0, 100000)
+        self.chunk_spin.setValue(0)
+        form.addRow("Contacts per file", self.chunk_spin)
 
         field_btn = QPushButton("Select Fields")
         field_btn.clicked.connect(lambda: self._stack.setCurrentIndex(1))
@@ -72,7 +80,7 @@ class ExportOptionsDialog(QDialog):
         layout.addWidget(back_btn)
         self._stack.addWidget(page)
 
-    def options(self) -> Tuple[str, bool, int, List[str]]:
+    def options(self) -> Tuple[str, bool, int, int, List[str], bool]:
         fields = [
             h for h, cb in self.field_checks.items() if cb.isChecked()
         ]
@@ -80,5 +88,7 @@ class ExportOptionsDialog(QDialog):
             self.folder_edit.text().strip(),
             self.tz_split.isChecked(),
             self.group_spin.value(),
+            self.chunk_spin.value(),
             fields,
+            self.export_all.isChecked(),
         )


### PR DESCRIPTION
## Summary
- allow splitting CSV export by chunk size via `chunk_size` parameter
- add option in export dialog to export all filtered contacts
- update contacts table to use new export options
- test new chunk splitting behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619582453083329947d07524fa286c